### PR TITLE
Feature add SynchronizeAsync

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,3 +35,5 @@ Extensions for concerns found in System.Reactive that make consuming the library
 - Shuffle
 - OnErrorRetry
 - TakeUntil
+- SyncronizeAsync
+- SubscribeSynchronus

--- a/src/ReactiveMarbles.Extensions.Tests/ReactiveExtensionsTests.cs
+++ b/src/ReactiveMarbles.Extensions.Tests/ReactiveExtensionsTests.cs
@@ -111,8 +111,6 @@ public class ReactiveExtensionsTests
             .Be(0);
     }
 
-
-
     /// <summary>
     /// Syncronizes the asynchronous runs with asynchronous tasks in subscriptions.
     /// </summary>
@@ -127,7 +125,7 @@ public class ReactiveExtensionsTests
             .SynchronizeAsync()
             .Subscribe(async x =>
             {
-                if (x.value)
+                if (x.Value)
                 {
                     await Task.Delay(1000);
                     result++;

--- a/src/ReactiveMarbles.Extensions/Continuation.cs
+++ b/src/ReactiveMarbles.Extensions/Continuation.cs
@@ -1,0 +1,91 @@
+﻿// Copyright (c) 2019-2023 ReactiveUI Association Incorporated. All rights reserved.
+// ReactiveUI Association Incorporated licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace ReactiveMarbles.Extensions;
+
+/// <summary>
+/// Continuation.
+/// </summary>
+public class Continuation : IDisposable
+{
+    private readonly Barrier _phaseSync = new(2);
+    private bool _disposedValue;
+    private bool _locked;
+
+    /// <summary>
+    /// Gets the number of completed phases.
+    /// </summary>
+    /// <value>
+    /// The completed phases.
+    /// </value>
+    public long CompletedPhases => _phaseSync.CurrentPhaseNumber;
+
+    /// <summary>
+    /// Performs application-defined tasks associated with freeing, releasing, or resetting unmanaged resources.
+    /// </summary>
+    public void Dispose()
+    {
+        // Do not change this code. Put cleanup code in 'Dispose(bool disposing)' method
+        Dispose(disposing: true);
+        GC.SuppressFinalize(this);
+    }
+
+    /// <summary>
+    /// Locks this instance.
+    /// </summary>
+    /// <typeparam name="T">The type of the elements in the source sequence.</typeparam>
+    /// <param name="item">The item.</param>
+    /// <param name="observer">The observer.</param>
+    /// <returns>
+    /// A <see cref="Task" /> representing the asynchronous operation.
+    /// </returns>
+    public Task Lock<T>(T item, IObserver<(T value, IDisposable Sync)> observer)
+    {
+        if (_locked)
+        {
+            return Task.CompletedTask;
+        }
+
+        _locked = true;
+        observer.OnNext((item, this));
+        return Task.Run(() => _phaseSync?.SignalAndWait(CancellationToken.None));
+    }
+
+    /// <summary>
+    /// Releases unmanaged and - optionally - managed resources.
+    /// </summary>
+    /// <param name="disposing"><c>true</c> to release both managed and unmanaged resources; <c>false</c> to release only unmanaged resources.</param>
+    protected virtual async void Dispose(bool disposing)
+    {
+        if (!_disposedValue)
+        {
+            if (disposing)
+            {
+                await UnLock();
+                _phaseSync.Dispose();
+            }
+
+            _disposedValue = true;
+        }
+    }
+
+    /// <summary>
+    /// UnLocks this instance.
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+    private Task UnLock()
+    {
+        if (!_locked)
+        {
+            return Task.CompletedTask;
+        }
+
+        _locked = false;
+        return Task.Run(() => _phaseSync?.SignalAndWait(CancellationToken.None));
+    }
+}


### PR DESCRIPTION
Add SubscribeSynchronus

Provides a way of synchronizing async methods within the reactive data flow.

Either use SynchronizeAsync and Dispose of Sync when you wish to allow the next value to flow

OR

use SubscribeSynchronus to use async calls within the Subscribe method and waiting for the method to complete before releasing the next item.