### PR TITLE
Perf: eliminate hot-path allocations, modernize C# usage

### DIFF
--- a/src/ReactiveUI.Extensions.Tests/Async/BridgeTests.cs
+++ b/src/ReactiveUI.Extensions.Tests/Async/BridgeTests.cs
@@ -739,4 +739,23 @@ public class BridgeTests
         await Assert.That(conditionMet).IsTrue();
         await Assert.That(receivedError!.Message).IsEqualTo("completion failure");
     }
+
+    /// <summary>Tests ToObservable bridge disposal when subscription task is already completed.</summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous test operation.</returns>
+    [Test]
+    public async Task WhenBridgeToObservableDisposedAfterCompletion_ThenCleansUp()
+    {
+        var source = new DirectSource<int>();
+        var bridged = source.ToObservable();
+        var items = new List<int>();
+
+        var sub = bridged.Subscribe(x => items.Add(x));
+
+        await source.EmitNext(42);
+        await Task.Delay(50);
+
+        sub.Dispose();
+
+        await Assert.That(items).Contains(42);
+    }
 }

--- a/src/ReactiveUI.Extensions.Tests/Async/CombineLatestOperatorTests.cs
+++ b/src/ReactiveUI.Extensions.Tests/Async/CombineLatestOperatorTests.cs
@@ -5560,4 +5560,76 @@ public class CombineLatestOperatorTests
         // No snapshots were ever emitted because not all sources had values.
         await Assert.That(emissions).IsEmpty();
     }
+
+    /// <summary>Tests CombineLatest error-resume after disposal is ignored.</summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous test operation.</returns>
+    [Test]
+    public async Task WhenCombineLatestDisposedThenErrorIgnored()
+    {
+        var source1 = new DirectSource<int>();
+        var source2 = new DirectSource<int>();
+        var items = new List<int>();
+
+        var sub = await ObservableAsync.CombineLatest(source1, source2, (a, b) => a + b)
+            .SubscribeAsync(
+                (x, _) =>
+                {
+                    items.Add(x);
+                    return default;
+                },
+                null,
+                null);
+
+        await source1.EmitNext(1);
+        await source2.EmitNext(2);
+        await sub.DisposeAsync();
+
+        // Emissions after disposal should be ignored
+        await source1.EmitNext(10);
+        await Assert.That(items).Count().IsEqualTo(1);
+    }
+
+    /// <summary>Tests CombineLatest error from source propagates.</summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous test operation.</returns>
+    [Test]
+    public async Task WhenCombineLatestSourceEmitsError_ThenErrorPropagated()
+    {
+        var error = new InvalidOperationException("src-error");
+        var source1 = new DirectSource<int>();
+        var source2 = new DirectSource<int>();
+        Exception? caughtError = null;
+
+        await using var sub = await ObservableAsync.CombineLatest(source1, source2, (a, b) => a + b)
+            .SubscribeAsync(
+                static (_, _) => default,
+                (ex, _) =>
+                {
+                    caughtError = ex;
+                    return default;
+                },
+                null);
+
+        await source1.EmitNext(1);
+        await source2.EmitNext(2);
+        await source1.EmitError(error);
+        await source1.Complete(Result.Success);
+        await source2.Complete(Result.Success);
+
+        await Assert.That(caughtError).IsNotNull();
+    }
+
+    /// <summary>Tests CombineLatestEnumerable where sources is already an IReadOnlyList.</summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous test operation.</returns>
+    [Test]
+    public async Task WhenCombineLatestWithReadOnlyListSources_ThenWorks()
+    {
+        IReadOnlyList<IObservableAsync<int>> sources =
+        [
+            ObservableAsync.Return(1),
+            ObservableAsync.Return(2)
+        ];
+
+        var result = await sources.CombineLatest().FirstAsync();
+        await Assert.That(result).Count().IsEqualTo(2);
+    }
 }

--- a/src/ReactiveUI.Extensions.Tests/Async/CombiningOperatorTests.cs
+++ b/src/ReactiveUI.Extensions.Tests/Async/CombiningOperatorTests.cs
@@ -5527,6 +5527,123 @@ public class CombiningOperatorTests
         await failTask;
     }
 
+    /// <summary>Tests Merge inner source failure propagates error.</summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous test operation.</returns>
+    [Test]
+    public async Task WhenMergeInnerSourceFails_ThenErrorPropagated()
+    {
+        var error = new InvalidOperationException("inner-error");
+        var inner = ObservableAsync.Throw<int>(error);
+        var outer = ObservableAsync.Return(inner);
+
+        Result? completionResult = null;
+        await using var sub = await outer.Merge()
+            .SubscribeAsync(
+                static (_, _) => default,
+                null,
+                result =>
+                {
+                    completionResult = result;
+                    return default;
+                });
+
+        await Task.Delay(100);
+
+        await Assert.That(completionResult).IsNotNull();
+        await Assert.That(completionResult!.Value.IsFailure).IsTrue();
+    }
+
+    /// <summary>Tests Merge with max concurrency inner failure propagates.</summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous test operation.</returns>
+    [Test]
+    public async Task WhenMergeWithMaxConcurrencyInnerFails_ThenErrorPropagated()
+    {
+        var error = new InvalidOperationException("merge-fail");
+        var inner = ObservableAsync.Throw<int>(error);
+        var outer = ObservableAsync.Return(inner);
+
+        Result? completionResult = null;
+        await using var sub = await outer.Merge(1)
+            .SubscribeAsync(
+                static (_, _) => default,
+                null,
+                result =>
+                {
+                    completionResult = result;
+                    return default;
+                });
+
+        await Task.Delay(100);
+
+        await Assert.That(completionResult).IsNotNull();
+        await Assert.That(completionResult!.Value.IsFailure).IsTrue();
+    }
+
+    /// <summary>Tests Concat with observable of observables inner failure propagates.</summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous test operation.</returns>
+    [Test]
+    public async Task WhenConcatObservablesInnerFails_ThenErrorPropagated()
+    {
+        var error = new InvalidOperationException("obs-concat-fail");
+        var outer = ObservableAsync.Return<IObservableAsync<int>>(ObservableAsync.Throw<int>(error));
+
+        await Assert.ThrowsAsync<InvalidOperationException>(async () =>
+            await outer.Concat().FirstAsync());
+    }
+
+    /// <summary>Tests Concat with enumerable source failure propagates.</summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous test operation.</returns>
+    [Test]
+    public async Task WhenConcatEnumerableInnerFails_ThenErrorPropagated()
+    {
+        var error = new InvalidOperationException("concat-fail");
+        var sources = new IObservableAsync<int>[]
+        {
+            ObservableAsync.Return(1),
+            ObservableAsync.Throw<int>(error)
+        };
+
+        await Assert.ThrowsAsync<InvalidOperationException>(async () =>
+            await ((IEnumerable<IObservableAsync<int>>)sources).Concat().LastAsync());
+    }
+
+    /// <summary>Tests Switch emits from the latest inner observable.</summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous test operation.</returns>
+    [Test]
+    public async Task WhenSwitchNewInnerArrives_ThenEmitsFromLatest()
+    {
+        var result = await ObservableAsync.Return<IObservableAsync<int>>(ObservableAsync.Return(42))
+            .Switch()
+            .FirstAsync();
+
+        await Assert.That(result).IsEqualTo(42);
+    }
+
+    /// <summary>Tests Switch inner failure propagates.</summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous test operation.</returns>
+    [Test]
+    public async Task WhenSwitchInnerFails_ThenErrorPropagated()
+    {
+        var error = new InvalidOperationException("switch-inner");
+
+        await Assert.ThrowsAsync<InvalidOperationException>(async () =>
+            await ObservableAsync.Return(ObservableAsync.Throw<int>(error))
+                .Switch()
+                .FirstAsync());
+    }
+
+    /// <summary>Tests Zip completes when shorter side finishes.</summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous test operation.</returns>
+    [Test]
+    public async Task WhenZipLeftShorter_ThenCompletesEarly()
+    {
+        var result = await ObservableAsync.Range(1, 2)
+            .Zip(ObservableAsync.Range(10, 5), (a, b) => a + b)
+            .ToListAsync();
+
+        await Assert.That(result).IsEquivalentTo([11, 13]);
+    }
+
     /// <summary>
     /// A trackable async disposable resource for verifying disposal in Using tests.
     /// </summary>

--- a/src/ReactiveUI.Extensions.Tests/Async/DisposableTests.cs
+++ b/src/ReactiveUI.Extensions.Tests/Async/DisposableTests.cs
@@ -976,6 +976,31 @@ public class DisposableTests
         await Assert.That(sad.IsDisposed).IsTrue();
     }
 
+    /// <summary>Tests CompositeDisposableAsync.CopyTo with negative index throws.</summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous test operation.</returns>
+    [Test]
+    public async Task WhenCopyToWithNegativeIndex_ThenThrows()
+    {
+        await using var composite = new CompositeDisposableAsync();
+        var array = new IAsyncDisposable[1];
+        Assert.Throws<ArgumentOutOfRangeException>(() => composite.CopyTo(array, -1));
+    }
+
+    /// <summary>Tests CompositeDisposableAsync.CopyTo with insufficient space throws.</summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous test operation.</returns>
+    [Test]
+    public async Task WhenCopyToWithInsufficientSpace_ThenThrows()
+    {
+        var composite = new CompositeDisposableAsync();
+        await composite.AddAsync(DisposableAsync.Empty);
+        await composite.AddAsync(DisposableAsync.Empty);
+
+        var array = new IAsyncDisposable[1];
+        Assert.Throws<ArgumentOutOfRangeException>(() => composite.CopyTo(array, 0));
+
+        await composite.DisposeAsync();
+    }
+
     /// <summary>
     /// Helper disposable for testing ToDisposableAsync.
     /// </summary>

--- a/src/ReactiveUI.Extensions.Tests/Async/ParityOperatorTests.cs
+++ b/src/ReactiveUI.Extensions.Tests/Async/ParityOperatorTests.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for full license information.
 
 using ReactiveUI.Extensions.Async;
+using ReactiveUI.Extensions.Async.Disposables;
 using ReactiveUI.Extensions.Async.Subjects;
 using AsyncObs = ReactiveUI.Extensions.Async.ObservableAsync;
 

--- a/src/ReactiveUI.Extensions.Tests/Async/ResultAndInfrastructureTests.cs
+++ b/src/ReactiveUI.Extensions.Tests/Async/ResultAndInfrastructureTests.cs
@@ -1858,6 +1858,97 @@ public class ResultAndInfrastructureTests
         await Assert.That(handledErrors[0]).IsSameReferenceAs(completionException);
     }
 
+    /// <summary>Tests SubjectAsync.Create with invalid PublishingOption throws.</summary>
+    [Test]
+    public void WhenSubjectAsyncCreateWithInvalidOptions_ThenThrows()
+    {
+        var options = new SubjectCreationOptions
+        {
+            PublishingOption = (PublishingOption)99,
+            IsStateless = false
+        };
+
+        Assert.Throws<ArgumentOutOfRangeException>(() => SubjectAsync.Create<int>(options));
+    }
+
+    /// <summary>Tests SubjectAsync.CreateBehavior with invalid PublishingOption throws.</summary>
+    [Test]
+    public void WhenBehaviorSubjectCreateWithInvalidOptions_ThenThrows()
+    {
+        var options = new BehaviorSubjectCreationOptions
+        {
+            PublishingOption = (PublishingOption)99,
+            IsStateless = false
+        };
+
+        Assert.Throws<ArgumentOutOfRangeException>(() => SubjectAsync.CreateBehavior<int>(0, options));
+    }
+
+    /// <summary>Tests SubjectAsync.CreateReplayLatest with invalid PublishingOption throws.</summary>
+    [Test]
+    public void WhenReplayLatestCreateWithInvalidOptions_ThenThrows()
+    {
+        var options = new ReplayLatestSubjectCreationOptions
+        {
+            PublishingOption = (PublishingOption)99,
+            IsStateless = false
+        };
+
+        Assert.Throws<ArgumentOutOfRangeException>(() => SubjectAsync.CreateReplayLatest<int>(options));
+    }
+
+    /// <summary>Tests AsyncContext.IsDefaultContext returns false for non-default context.</summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous test operation.</returns>
+    [Test]
+    public async Task WhenAsyncContextIsNotDefault_ThenIsDefaultContextIsFalse()
+    {
+        var sc = new SynchronizationContext();
+        var ctx = AsyncContext.From(sc);
+        await Assert.That(ctx.IsDefaultContext).IsFalse();
+    }
+
+    /// <summary>Tests AsyncContext.SwitchContextAsync with default context and force yielding.</summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous test operation.</returns>
+    [Test]
+    public async Task WhenSwitchContextAsyncWithDefaultContext_ThenCompletes()
+    {
+        var ctx = AsyncContext.Default;
+        await ctx.SwitchContextAsync(forceYielding: true, CancellationToken.None);
+    }
+
+    /// <summary>Tests SubscriptionHelper returns subscription on success.</summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous test operation.</returns>
+    [Test]
+    public async Task WhenSubscriptionHelperSucceeds_ThenReturnsSubscription()
+    {
+        var disposable = DisposableAsync.Empty;
+        var result = await SubscriptionHelper.SubscribeAndDisposeOnFailureAsync(
+            disposable,
+            () => default);
+
+        await Assert.That(result).IsEqualTo(disposable);
+    }
+
+    /// <summary>Tests SubscriptionHelper disposes subscription and rethrows on failure.</summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous test operation.</returns>
+    [Test]
+    public async Task WhenSubscriptionHelperFails_ThenDisposesAndRethrows()
+    {
+        var disposed = false;
+        var disposable = DisposableAsync.Create(() =>
+        {
+            disposed = true;
+            return default;
+        });
+
+        await Assert.ThrowsAsync<InvalidOperationException>(async () =>
+            await SubscriptionHelper.SubscribeAndDisposeOnFailureAsync(
+                disposable,
+                () => throw new InvalidOperationException("subscribe-fail")));
+
+        await Assert.That(disposed).IsTrue();
+    }
+
     /// <summary>
     /// A concrete <see cref="ObserverAsync{T}"/> implementation for testing, with
     /// configurable behavior for each virtual method.

--- a/src/ReactiveUI.Extensions.Tests/Async/SubjectTests.cs
+++ b/src/ReactiveUI.Extensions.Tests/Async/SubjectTests.cs
@@ -1542,4 +1542,131 @@ public class SubjectTests
         await Assert.That(lateResult).IsNotNull();
         await Assert.That(lateResult!.Value.IsSuccess).IsTrue();
     }
+
+    /// <summary>Tests that concurrent subject forwards OnNext to multiple observers concurrently.</summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous test operation.</returns>
+    [Test]
+    public async Task WhenConcurrentSubjectWithMultipleObservers_ThenAllReceiveOnNext()
+    {
+        var subject = SubjectAsync.Create<int>(new SubjectCreationOptions
+        {
+            PublishingOption = PublishingOption.Concurrent,
+            IsStateless = false
+        });
+        var items1 = new List<int>();
+        var items2 = new List<int>();
+
+        await using var sub1 = await subject.Values.SubscribeAsync(
+            (x, _) =>
+            {
+                lock (items1)
+                {
+                    items1.Add(x);
+                }
+
+                return default;
+            },
+            null,
+            null);
+        await using var sub2 = await subject.Values.SubscribeAsync(
+            (x, _) =>
+            {
+                lock (items2)
+                {
+                    items2.Add(x);
+                }
+
+                return default;
+            },
+            null,
+            null);
+
+        await subject.OnNextAsync(42, CancellationToken.None);
+        await subject.OnCompletedAsync(Result.Success);
+
+        await Assert.That(items1).IsEquivalentTo([42]);
+        await Assert.That(items2).IsEquivalentTo([42]);
+    }
+
+    /// <summary>Tests that concurrent subject forwards OnErrorResume to multiple observers concurrently.</summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous test operation.</returns>
+    [Test]
+    public async Task WhenConcurrentSubjectWithMultipleObservers_ThenAllReceiveOnErrorResume()
+    {
+        var subject = SubjectAsync.Create<int>(new SubjectCreationOptions
+        {
+            PublishingOption = PublishingOption.Concurrent,
+            IsStateless = false
+        });
+        var errors1 = new List<Exception>();
+        var errors2 = new List<Exception>();
+        var error = new InvalidOperationException("test");
+
+        await using var sub1 = await subject.Values.SubscribeAsync(
+            static (_, _) => default,
+            (ex, _) =>
+            {
+                lock (errors1)
+                {
+                    errors1.Add(ex);
+                }
+
+                return default;
+            },
+            null);
+        await using var sub2 = await subject.Values.SubscribeAsync(
+            static (_, _) => default,
+            (ex, _) =>
+            {
+                lock (errors2)
+                {
+                    errors2.Add(ex);
+                }
+
+                return default;
+            },
+            null);
+
+        await subject.OnErrorResumeAsync(error, CancellationToken.None);
+        await subject.OnCompletedAsync(Result.Success);
+
+        await Assert.That(errors1).Count().IsEqualTo(1);
+        await Assert.That(errors2).Count().IsEqualTo(1);
+    }
+
+    /// <summary>Tests that concurrent subject forwards OnCompleted to multiple observers concurrently.</summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous test operation.</returns>
+    [Test]
+    public async Task WhenConcurrentSubjectWithMultipleObservers_ThenAllReceiveOnCompleted()
+    {
+        var subject = SubjectAsync.Create<int>(new SubjectCreationOptions
+        {
+            PublishingOption = PublishingOption.Concurrent,
+            IsStateless = false
+        });
+        var completed1 = new TaskCompletionSource();
+        var completed2 = new TaskCompletionSource();
+
+        await using var sub1 = await subject.Values.SubscribeAsync(
+            static (_, _) => default,
+            null,
+            result =>
+            {
+                completed1.TrySetResult();
+                return default;
+            });
+        await using var sub2 = await subject.Values.SubscribeAsync(
+            static (_, _) => default,
+            null,
+            result =>
+            {
+                completed2.TrySetResult();
+                return default;
+            });
+
+        await subject.OnCompletedAsync(Result.Success);
+
+        await completed1.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        await completed2.Task.WaitAsync(TimeSpan.FromSeconds(5));
+    }
 }

--- a/src/ReactiveUI.Extensions.Tests/Async/TakeUntilOperatorTests.cs
+++ b/src/ReactiveUI.Extensions.Tests/Async/TakeUntilOperatorTests.cs
@@ -2016,4 +2016,92 @@ public class TakeUntilOperatorTests
 
         await sub.DisposeAsync();
     }
+
+    /// <summary>Tests TakeUntil with sync predicate stops when predicate is true.</summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous test operation.</returns>
+    [Test]
+    public async Task WhenTakeUntilSyncPredicate_ThenStopsWhenTrue()
+    {
+        var result = await ObservableAsync.Range(1, 10)
+            .TakeUntil(x => x >= 3)
+            .ToListAsync();
+
+        await Assert.That(result).Contains(1);
+        await Assert.That(result).Contains(2);
+        await Assert.That(result).DoesNotContain(4);
+    }
+
+    /// <summary>Tests TakeUntil with async predicate stops when predicate is true.</summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous test operation.</returns>
+    [Test]
+    public async Task WhenTakeUntilAsyncPredicate_ThenStopsWhenTrue()
+    {
+        var result = await ObservableAsync.Range(1, 10)
+            .TakeUntil((x, _) => new ValueTask<bool>(x >= 3))
+            .ToListAsync();
+
+        await Assert.That(result).Contains(1);
+        await Assert.That(result).Contains(2);
+        await Assert.That(result).DoesNotContain(4);
+    }
+
+    /// <summary>Tests TakeUntil with CancellationToken completes when token fires.</summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous test operation.</returns>
+    [Test]
+    public async Task WhenTakeUntilCancellationToken_ThenCompletesOnCancel()
+    {
+        var cts = new CancellationTokenSource();
+        var source = new DirectSource<int>();
+        var items = new List<int>();
+        var completed = new TaskCompletionSource();
+
+        await using var sub = await source.TakeUntil(cts.Token).SubscribeAsync(
+            (x, _) =>
+            {
+                items.Add(x);
+                return default;
+            },
+            null,
+            _ =>
+            {
+                completed.TrySetResult();
+                return default;
+            });
+
+        await source.EmitNext(1);
+        cts.Cancel();
+        await completed.Task.WaitAsync(TimeSpan.FromSeconds(5));
+
+        await Assert.That(items).Contains(1);
+    }
+
+    /// <summary>Tests TakeUntil with Task completes when task finishes.</summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous test operation.</returns>
+    [Test]
+    public async Task WhenTakeUntilTaskCompletes_ThenSourceCompletes()
+    {
+        var tcs = new TaskCompletionSource();
+        var source = new DirectSource<int>();
+        var items = new List<int>();
+        var completed = new TaskCompletionSource();
+
+        await using var sub = await source.TakeUntil(tcs.Task).SubscribeAsync(
+            (x, _) =>
+            {
+                items.Add(x);
+                return default;
+            },
+            null,
+            _ =>
+            {
+                completed.TrySetResult();
+                return default;
+            });
+
+        await source.EmitNext(1);
+        tcs.SetResult();
+        await completed.Task.WaitAsync(TimeSpan.FromSeconds(5));
+
+        await Assert.That(items).Contains(1);
+    }
 }

--- a/src/ReactiveUI.Extensions.Tests/Async/TerminalOperatorTests.cs
+++ b/src/ReactiveUI.Extensions.Tests/Async/TerminalOperatorTests.cs
@@ -1218,4 +1218,198 @@ public class TerminalOperatorTests
 
         await Assert.That(items).IsEquivalentTo([10, 20, 30, 40, 50]);
     }
+
+    /// <summary>Tests AggregateAsync propagates source failure.</summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous test operation.</returns>
+    [Test]
+    public async Task WhenAggregateAsyncSourceFails_ThenThrows()
+    {
+        var error = new InvalidOperationException("test");
+        await Assert.ThrowsAsync<InvalidOperationException>(
+            async () => await ObservableAsync.Throw<int>(error).AggregateAsync(0, (acc, x) => acc + x));
+    }
+
+    /// <summary>Tests AnyAsync propagates source failure.</summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous test operation.</returns>
+    [Test]
+    public async Task WhenAnyAsyncSourceFails_ThenThrows()
+    {
+        await Assert.ThrowsAsync<InvalidOperationException>(
+            async () => await ObservableAsync.Throw<int>(new InvalidOperationException("fail")).AnyAsync());
+    }
+
+    /// <summary>Tests AllAsync propagates source failure.</summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous test operation.</returns>
+    [Test]
+    public async Task WhenAllAsyncSourceFails_ThenThrows()
+    {
+        await Assert.ThrowsAsync<InvalidOperationException>(
+            async () => await ObservableAsync.Throw<int>(new InvalidOperationException("fail")).AllAsync(_ => true));
+    }
+
+    /// <summary>Tests ContainsAsync propagates source failure.</summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous test operation.</returns>
+    [Test]
+    public async Task WhenContainsAsyncSourceFails_ThenThrows()
+    {
+        await Assert.ThrowsAsync<InvalidOperationException>(
+            async () => await ObservableAsync.Throw<int>(new InvalidOperationException("fail")).ContainsAsync(1));
+    }
+
+    /// <summary>Tests CountAsync propagates source failure.</summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous test operation.</returns>
+    [Test]
+    public async Task WhenCountAsyncSourceFails_ThenThrows()
+    {
+        await Assert.ThrowsAsync<InvalidOperationException>(
+            async () => await ObservableAsync.Throw<int>(new InvalidOperationException("fail")).CountAsync());
+    }
+
+    /// <summary>Tests LongCountAsync propagates source failure.</summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous test operation.</returns>
+    [Test]
+    public async Task WhenLongCountAsyncSourceFails_ThenThrows()
+    {
+        await Assert.ThrowsAsync<InvalidOperationException>(
+            async () => await ObservableAsync.Throw<int>(new InvalidOperationException("fail")).LongCountAsync());
+    }
+
+    /// <summary>Tests SingleAsync propagates source failure.</summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous test operation.</returns>
+    [Test]
+    public async Task WhenSingleAsyncSourceFails_ThenThrows()
+    {
+        await Assert.ThrowsAsync<InvalidOperationException>(
+            async () => await ObservableAsync.Throw<int>(new InvalidOperationException("fail")).SingleAsync());
+    }
+
+    /// <summary>Tests FirstAsync propagates source failure.</summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous test operation.</returns>
+    [Test]
+    public async Task WhenFirstAsyncSourceFails_ThenThrows()
+    {
+        await Assert.ThrowsAsync<InvalidOperationException>(
+            async () => await ObservableAsync.Throw<int>(new InvalidOperationException("fail")).FirstAsync());
+    }
+
+    /// <summary>Tests FirstOrDefaultAsync propagates source failure.</summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous test operation.</returns>
+    [Test]
+    public async Task WhenFirstOrDefaultAsyncSourceFails_ThenThrows()
+    {
+        await Assert.ThrowsAsync<InvalidOperationException>(
+            async () => await ObservableAsync.Throw<int>(new InvalidOperationException("fail")).FirstOrDefaultAsync());
+    }
+
+    /// <summary>Tests WaitCompletionAsync propagates source failure.</summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous test operation.</returns>
+    [Test]
+    public async Task WhenWaitCompletionAsyncSourceFails_ThenThrows()
+    {
+        await Assert.ThrowsAsync<InvalidOperationException>(
+            async () => await ObservableAsync.Throw<int>(new InvalidOperationException("fail")).WaitCompletionAsync());
+    }
+
+    /// <summary>Tests ContainsAsync when value is not found returns false.</summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous test operation.</returns>
+    [Test]
+    public async Task WhenContainsAsyncValueNotFound_ThenReturnsFalse()
+    {
+        var result = await ObservableAsync.Range(1, 3).ContainsAsync(99);
+        await Assert.That(result).IsFalse();
+    }
+
+    /// <summary>Tests CountAsync with predicate that filters some elements.</summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous test operation.</returns>
+    [Test]
+    public async Task WhenCountAsyncWithPredicate_ThenCountsMatchesOnly()
+    {
+        var result = await ObservableAsync.Range(1, 5).CountAsync(x => x > 3);
+        await Assert.That(result).IsEqualTo(2);
+    }
+
+    /// <summary>Tests LongCountAsync with predicate that filters some elements.</summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous test operation.</returns>
+    [Test]
+    public async Task WhenLongCountAsyncWithPredicate_ThenCountsMatchesOnly()
+    {
+        var result = await ObservableAsync.Range(1, 5).LongCountAsync(x => x > 3);
+        await Assert.That(result).IsEqualTo(2L);
+    }
+
+    /// <summary>Tests FirstOrDefaultAsync on empty returns default.</summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous test operation.</returns>
+    [Test]
+    public async Task WhenFirstOrDefaultAsyncOnEmpty_ThenReturnsDefault()
+    {
+        var result = await ObservableAsync.Empty<int>().FirstOrDefaultAsync();
+        await Assert.That(result).IsEqualTo(0);
+    }
+
+    /// <summary>Tests WaitCompletionAsync on successful sequence completes without error.</summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous test operation.</returns>
+    [Test]
+    public async Task WhenWaitCompletionAsyncOnSuccess_ThenCompletes()
+    {
+        await ObservableAsync.Return(42).WaitCompletionAsync();
+    }
+
+    /// <summary>Tests ForEachAsync with null sync action throws ArgumentNullException.</summary>
+    [Test]
+    public void WhenForEachAsyncWithNullSyncAction_ThenThrowsArgumentNullException()
+    {
+        Assert.ThrowsAsync<ArgumentNullException>(
+            async () => await ObservableAsync.Return(1).ForEachAsync((Action<int>)null!));
+    }
+
+    /// <summary>Tests ForEachAsync with null async action throws ArgumentNullException.</summary>
+    [Test]
+    public void WhenForEachAsyncWithNullAsyncAction_ThenThrowsArgumentNullException()
+    {
+        Assert.ThrowsAsync<ArgumentNullException>(
+            async () => await ObservableAsync.Return(1).ForEachAsync((Func<int, CancellationToken, ValueTask>)null!));
+    }
+
+    /// <summary>Tests async ForEachAsync propagates source failure.</summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous test operation.</returns>
+    [Test]
+    public async Task WhenForEachAsyncSourceFails_ThenThrows()
+    {
+        var error = new InvalidOperationException("test");
+        await Assert.ThrowsAsync<InvalidOperationException>(
+            async () => await ObservableAsync.Throw<int>(error).ForEachAsync((_, _) => default));
+    }
+
+    /// <summary>Tests sync ForEachAsync propagates source failure.</summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous test operation.</returns>
+    [Test]
+    public async Task WhenForEachAsyncSyncOverloadSourceFails_ThenThrows()
+    {
+        var error = new InvalidOperationException("test");
+        await Assert.ThrowsAsync<InvalidOperationException>(
+            async () => await ObservableAsync.Throw<int>(error).ForEachAsync(_ => { }));
+    }
+
+    /// <summary>Tests ToAsyncEnumerable propagates source failure.</summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous test operation.</returns>
+    [Test]
+    public async Task WhenToAsyncEnumerableSourceFails_ThenThrows()
+    {
+        var error = new InvalidOperationException("enum-error");
+        await Assert.ThrowsAsync<InvalidOperationException>(async () =>
+        {
+            await foreach (var item in ObservableAsync.Throw<int>(error).ToAsyncEnumerable(
+                () => Channel.CreateUnbounded<int>()))
+            {
+                _ = item;
+            }
+        });
+    }
+
+    /// <summary>Tests Wrap with a null observer throws ArgumentNullException.</summary>
+    [Test]
+    public void WhenWrapWithNullObserver_ThenThrowsArgumentNullException()
+    {
+        Assert.Throws<ArgumentNullException>(() => ObservableAsync.Wrap<int>(null!));
+    }
 }

--- a/src/ReactiveUI.Extensions.Tests/Async/TimeBasedOperatorTests.cs
+++ b/src/ReactiveUI.Extensions.Tests/Async/TimeBasedOperatorTests.cs
@@ -780,6 +780,131 @@ public class TimeBasedOperatorTests
         }
     }
 
+    /// <summary>Tests Interval stops when cancelled.</summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous test operation.</returns>
+    [Test]
+    public async Task WhenIntervalCancelled_ThenStops()
+    {
+        var cts = new CancellationTokenSource();
+        var items = new List<long>();
+
+        await using var sub = await ObservableAsync.Interval(TimeSpan.FromMilliseconds(10))
+            .SubscribeAsync(
+                (x, _) =>
+                {
+                    items.Add(x);
+                    if (x >= 2)
+                    {
+                        cts.Cancel();
+                    }
+
+                    return default;
+                },
+                null,
+                null,
+                cts.Token);
+
+        await Task.Delay(200);
+        await Assert.That(items.Count).IsGreaterThanOrEqualTo(2);
+    }
+
+    /// <summary>Tests Timer with period stops when cancelled.</summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous test operation.</returns>
+    [Test]
+    public async Task WhenTimerWithPeriodCancelled_ThenStops()
+    {
+        var cts = new CancellationTokenSource();
+        var items = new List<long>();
+
+        await using var sub = await ObservableAsync.Timer(TimeSpan.FromMilliseconds(1), TimeSpan.FromMilliseconds(10))
+            .SubscribeAsync(
+                (x, _) =>
+                {
+                    items.Add(x);
+                    if (x >= 2)
+                    {
+                        cts.Cancel();
+                    }
+
+                    return default;
+                },
+                null,
+                null,
+                cts.Token);
+
+        await Task.Delay(200);
+        await Assert.That(items.Count).IsGreaterThanOrEqualTo(2);
+    }
+
+    /// <summary>Tests Throttle supersedes older values and only emits latest.</summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous test operation.</returns>
+    [Test]
+    public async Task WhenThrottleReceivesRapidValues_ThenOnlyEmitsLatest()
+    {
+        var source = new DirectSource<int>();
+        var items = new List<int>();
+        var completed = new TaskCompletionSource();
+
+        await using var sub = await source.Throttle(TimeSpan.FromMilliseconds(50))
+            .SubscribeAsync(
+                (x, _) =>
+                {
+                    items.Add(x);
+                    return default;
+                },
+                null,
+                _ =>
+                {
+                    completed.TrySetResult();
+                    return default;
+                });
+
+        await source.EmitNext(1);
+        await source.EmitNext(2);
+        await source.EmitNext(3);
+
+        await Task.Delay(200);
+        await source.Complete(Result.Success);
+        await completed.Task.WaitAsync(TimeSpan.FromSeconds(5));
+
+        await Assert.That(items).Contains(3);
+    }
+
+    /// <summary>Tests Timeout fires when source is slow.</summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous test operation.</returns>
+    [Test]
+    public async Task WhenTimeoutFires_ThenThrowsTimeoutException()
+    {
+        await Assert.ThrowsAsync<TimeoutException>(async () =>
+            await ObservableAsync.Never<int>()
+                .Timeout(TimeSpan.FromMilliseconds(10))
+                .FirstAsync());
+    }
+
+    /// <summary>Tests Timeout with fallback observable.</summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous test operation.</returns>
+    [Test]
+    public async Task WhenTimeoutWithFallback_ThenFallbackUsed()
+    {
+        var result = await ObservableAsync.Never<int>()
+            .Timeout(TimeSpan.FromMilliseconds(10), ObservableAsync.Return(99))
+            .FirstAsync();
+
+        await Assert.That(result).IsEqualTo(99);
+    }
+
+    /// <summary>Tests Timeout resets on each value and does not fire.</summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous test operation.</returns>
+    [Test]
+    public async Task WhenTimeoutResetsOnValue_ThenDoesNotFire()
+    {
+        var result = await ObservableAsync.Range(1, 3)
+            .Timeout(TimeSpan.FromSeconds(5))
+            .ToListAsync();
+
+        await Assert.That(result).IsEquivalentTo([1, 2, 3]);
+    }
+
     /// <summary>
     /// A custom <see cref="TimeProvider"/> that delegates timer creation to the system provider.
     /// Used to exercise the non-system <see cref="TimeProvider"/> code paths in Interval and Timer operators.

--- a/src/ReactiveUI.Extensions.Tests/Async/TransformationOperatorTests.cs
+++ b/src/ReactiveUI.Extensions.Tests/Async/TransformationOperatorTests.cs
@@ -872,6 +872,63 @@ public class TransformationOperatorTests
         }
     }
 
+    /// <summary>Tests Do with onErrorResume callback invokes callback on error.</summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous test operation.</returns>
+    [Test]
+    public async Task WhenDoWithOnErrorResume_ThenCallbackInvoked()
+    {
+        var directSource = new DirectSource<int>();
+        var errors = new List<Exception>();
+        var error = new InvalidOperationException("test");
+
+        await using var sub = await directSource.Do(onErrorResume: ex => errors.Add(ex)).SubscribeAsync(
+            static (_, _) => default,
+            static (_, _) => default,
+            static _ => default);
+
+        await directSource.EmitError(error);
+        await directSource.Complete(Result.Success);
+
+        await Assert.That(errors).Count().IsEqualTo(1);
+    }
+
+    /// <summary>Tests GroupBy source failure propagates.</summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous test operation.</returns>
+    [Test]
+    public async Task WhenGroupBySourceFails_ThenErrorPropagated()
+    {
+        var error = new InvalidOperationException("group-fail");
+
+        await Assert.ThrowsAsync<InvalidOperationException>(async () =>
+            await ObservableAsync.Throw<int>(error)
+                .GroupBy(x => x % 2)
+                .FirstAsync());
+    }
+
+    /// <summary>Tests Using operator disposes resource on source failure.</summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous test operation.</returns>
+    [Test]
+    public async Task WhenUsingSourceThrows_ThenResourceDisposed()
+    {
+        var disposed = false;
+        var error = new InvalidOperationException("test");
+
+        await Assert.ThrowsAsync<InvalidOperationException>(async () =>
+            await ObservableAsync.Using(
+                    async _ =>
+                    {
+                        return DisposableAsync.Create(() =>
+                        {
+                            disposed = true;
+                            return default;
+                        });
+                    },
+                    _ => ObservableAsync.Throw<int>(error))
+                .FirstAsync());
+
+        await Assert.That(disposed).IsTrue();
+    }
+
     /// <summary>
     /// A raw <see cref="IObserverAsync{T}"/> implementation that throws a specified exception
     /// from <see cref="OnCompletedAsync"/>. Unlike <see cref="ObserverAsync{T}"/>, this

--- a/src/ReactiveUI.Extensions/Async/Disposables/CompositeDisposableAsync.cs
+++ b/src/ReactiveUI.Extensions/Async/Disposables/CompositeDisposableAsync.cs
@@ -224,9 +224,9 @@ public sealed class CompositeDisposableAsync : IAsyncDisposable
 
         try
         {
-            foreach (var item in targetDisposables.Take(clearCount))
+            for (var i = 0; i < clearCount; i++)
             {
-                if (item != null)
+                if (targetDisposables[i] is { } item)
                 {
                     await item.DisposeAsync();
                 }

--- a/src/ReactiveUI.Extensions/Async/Disposables/DisposableAsync.cs
+++ b/src/ReactiveUI.Extensions/Async/Disposables/DisposableAsync.cs
@@ -27,10 +27,7 @@ public static class DisposableAsync
     /// <returns>An <see cref="IAsyncDisposable"/> instance that invokes the specified delegate when disposed asynchronously.</returns>
     public static IAsyncDisposable Create(Func<ValueTask> disposeAsync)
     {
-        if (disposeAsync == null)
-        {
-            throw new ArgumentNullException(nameof(disposeAsync), "Cannot create an IAsyncDisposable with a null dispose delegate.");
-        }
+        ArgumentExceptionHelper.ThrowIfNull(disposeAsync, nameof(disposeAsync));
 
         return new AnonymousAsyncDisposable(disposeAsync);
     }

--- a/src/ReactiveUI.Extensions/Async/Internals/AsyncGate.cs
+++ b/src/ReactiveUI.Extensions/Async/Internals/AsyncGate.cs
@@ -9,7 +9,7 @@ namespace ReactiveUI.Extensions.Async.Internals;
 /// <summary>
 /// Provides an asynchronous reentrant lock that allows recursive acquisition from the same async context.
 /// </summary>
-internal class AsyncGate : IDisposable
+internal sealed class AsyncGate : IDisposable
 {
     /// <summary>
     /// Synchronization gate protecting the recursion count and semaphore access.
@@ -68,8 +68,11 @@ internal class AsyncGate : IDisposable
     /// <inheritdoc/>
     public void Dispose()
     {
-        Dispose(disposing: true);
-        GC.SuppressFinalize(this);
+        if (!_disposedValue)
+        {
+            _semaphore.Dispose();
+            _disposedValue = true;
+        }
     }
 
     /// <summary>
@@ -85,23 +88,6 @@ internal class AsyncGate : IDisposable
             {
                 _semaphore.Release();
             }
-        }
-    }
-
-    /// <summary>
-    /// Releases the resources used by the <see cref="AsyncGate"/>.
-    /// </summary>
-    /// <param name="disposing"><see langword="true"/> to release managed resources; otherwise, <see langword="false"/>.</param>
-    protected virtual void Dispose(bool disposing)
-    {
-        if (!_disposedValue)
-        {
-            if (disposing)
-            {
-                _semaphore.Dispose();
-            }
-
-            _disposedValue = true;
         }
     }
 

--- a/src/ReactiveUI.Extensions/Async/Internals/SubscriptionHelper.cs
+++ b/src/ReactiveUI.Extensions/Async/Internals/SubscriptionHelper.cs
@@ -1,0 +1,37 @@
+// Copyright (c) 2019-2026 ReactiveUI Association Incorporated. All rights reserved.
+// ReactiveUI Association Incorporated licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+namespace ReactiveUI.Extensions.Async.Internals;
+
+/// <summary>
+/// Provides a helper for safely subscribing an <see cref="IAsyncDisposable"/> subscription,
+/// ensuring the subscription is disposed if the subscribe action throws.
+/// </summary>
+internal static class SubscriptionHelper
+{
+    /// <summary>
+    /// Executes <paramref name="subscribeAsync"/> and returns <paramref name="subscription"/>.
+    /// If <paramref name="subscribeAsync"/> throws, <paramref name="subscription"/> is disposed
+    /// before the exception propagates.
+    /// </summary>
+    /// <param name="subscription">The subscription to manage.</param>
+    /// <param name="subscribeAsync">The async action that wires up the subscription.</param>
+    /// <returns>The subscription if successful.</returns>
+    internal static async ValueTask<IAsyncDisposable> SubscribeAndDisposeOnFailureAsync(
+        IAsyncDisposable subscription,
+        Func<ValueTask> subscribeAsync)
+    {
+        try
+        {
+            await subscribeAsync();
+        }
+        catch
+        {
+            await subscription.DisposeAsync();
+            throw;
+        }
+
+        return subscription;
+    }
+}

--- a/src/ReactiveUI.Extensions/Async/Internals/WrappedObserverAsync.cs
+++ b/src/ReactiveUI.Extensions/Async/Internals/WrappedObserverAsync.cs
@@ -2,22 +2,21 @@
 // ReactiveUI Association Incorporated licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-namespace ReactiveUI.Extensions.Async.Internals
+namespace ReactiveUI.Extensions.Async.Internals;
+
+/// <summary>
+/// Wraps an <see cref="IObserverAsync{T}"/> to provide base observer behavior while delegating all notifications.
+/// </summary>
+/// <typeparam name="T">The type of elements received by the observer.</typeparam>
+/// <param name="observer">The inner observer to delegate notifications to.</param>
+internal sealed class WrappedObserverAsync<T>(IObserverAsync<T> observer) : ObserverAsync<T>
 {
-    /// <summary>
-    /// Wraps an <see cref="IObserverAsync{T}"/> to provide base observer behavior while delegating all notifications.
-    /// </summary>
-    /// <typeparam name="T">The type of elements received by the observer.</typeparam>
-    /// <param name="observer">The inner observer to delegate notifications to.</param>
-    internal sealed class WrappedObserverAsync<T>(IObserverAsync<T> observer) : ObserverAsync<T>
-    {
-        /// <inheritdoc/>
-        protected override ValueTask OnNextAsyncCore(T value, CancellationToken cancellationToken) => observer.OnNextAsync(value, cancellationToken);
+    /// <inheritdoc/>
+    protected override ValueTask OnNextAsyncCore(T value, CancellationToken cancellationToken) => observer.OnNextAsync(value, cancellationToken);
 
-        /// <inheritdoc/>
-        protected override ValueTask OnErrorResumeAsyncCore(Exception error, CancellationToken cancellationToken) => observer.OnErrorResumeAsync(error, cancellationToken);
+    /// <inheritdoc/>
+    protected override ValueTask OnErrorResumeAsyncCore(Exception error, CancellationToken cancellationToken) => observer.OnErrorResumeAsync(error, cancellationToken);
 
-        /// <inheritdoc/>
-        protected override ValueTask OnCompletedAsyncCore(Result result) => observer.OnCompletedAsync(result);
-    }
+    /// <inheritdoc/>
+    protected override ValueTask OnCompletedAsyncCore(Result result) => observer.OnCompletedAsync(result);
 }

--- a/src/ReactiveUI.Extensions/Async/ObservableAsync.cs
+++ b/src/ReactiveUI.Extensions/Async/ObservableAsync.cs
@@ -26,11 +26,8 @@ public abstract class ObservableAsync<T> : IObservableAsync<T>
     /// <param name="cancellationToken">A cancellation token that can be used to cancel the subscription operation.</param>
     /// <returns>A task that represents the asynchronous operation. The result contains an <see cref="IAsyncDisposable"/> that
     /// can be disposed to unsubscribe the observer.</returns>
-    public async ValueTask<IAsyncDisposable> SubscribeAsync(IObserverAsync<T> observer, CancellationToken cancellationToken)
-    {
-        var subscription = await SubscribeAsyncCore(observer, cancellationToken).ConfigureAwait(false);
-        return subscription;
-    }
+    public ValueTask<IAsyncDisposable> SubscribeAsync(IObserverAsync<T> observer, CancellationToken cancellationToken) =>
+        SubscribeAsyncCore(observer, cancellationToken);
 
     /// <summary>
     /// Subscribes the specified asynchronous observer to receive notifications from the observable sequence.

--- a/src/ReactiveUI.Extensions/Async/ObserverAsync.cs
+++ b/src/ReactiveUI.Extensions/Async/ObserverAsync.cs
@@ -31,6 +31,15 @@ public abstract class ObserverAsync<T> : IObserverAsync<T>
     private readonly CancellationTokenSource _disposeCts = new();
 
     /// <summary>
+    /// Synchronization gate protecting mutable state (_callsCount, _reentrantCallsCount, _allCallsCompletedTcs).
+    /// </summary>
+#if NET9_0_OR_GREATER
+    private readonly Lock _gate = new();
+#else
+    private readonly object _gate = new();
+#endif
+
+    /// <summary>
     /// The total number of currently executing <c>OnNext</c>, <c>OnErrorResume</c>, or <c>OnCompleted</c> calls.
     /// </summary>
     private int _callsCount;
@@ -58,26 +67,25 @@ public abstract class ObserverAsync<T> : IObserverAsync<T>
     /// <returns>A task that represents the asynchronous operation.</returns>
     public async ValueTask OnNextAsync(T value, CancellationToken cancellationToken)
     {
-        if (!TryEnterOnSomethingCall(cancellationToken, out var linkedCts))
+        if (!TryEnterOnSomethingCall(cancellationToken, out var scope))
         {
             return;
         }
 
-        var linkedToken = linkedCts.Token;
         try
         {
-            await OnNextAsyncCore(value, linkedToken);
+            await OnNextAsyncCore(value, scope.Token);
         }
         catch (OperationCanceledException)
         {
         }
         catch (Exception e)
         {
-            await OnErrorResumeAsync_Private(e, linkedToken);
+            await OnErrorResumeAsync_Private(e, scope.Token);
         }
         finally
         {
-            linkedCts.Dispose();
+            scope.Dispose();
             ExitOnSomethingCall();
         }
     }
@@ -90,18 +98,18 @@ public abstract class ObserverAsync<T> : IObserverAsync<T>
     /// <returns>A task that represents the asynchronous error handling operation.</returns>
     public async ValueTask OnErrorResumeAsync(Exception error, CancellationToken cancellationToken)
     {
-        if (!TryEnterOnSomethingCall(cancellationToken, out var linkedCts))
+        if (!TryEnterOnSomethingCall(cancellationToken, out var scope))
         {
             return;
         }
 
         try
         {
-            await OnErrorResumeAsync_Private(error, linkedCts.Token);
+            await OnErrorResumeAsync_Private(error, scope.Token);
         }
         finally
         {
-            linkedCts.Dispose();
+            scope.Dispose();
             ExitOnSomethingCall();
         }
     }
@@ -117,7 +125,7 @@ public abstract class ObserverAsync<T> : IObserverAsync<T>
     [DebuggerStepThrough]
     public async ValueTask OnCompletedAsync(Result result)
     {
-        if (!TryEnterOnSomethingCall(CancellationToken.None, out var linkedCts))
+        if (!TryEnterOnSomethingCall(CancellationToken.None, out var scope))
         {
             return;
         }
@@ -132,7 +140,7 @@ public abstract class ObserverAsync<T> : IObserverAsync<T>
         }
         finally
         {
-            linkedCts.Dispose();
+            scope.Dispose();
             if (ExitOnSomethingCall())
             {
                 await DisposeAsync();
@@ -152,7 +160,7 @@ public abstract class ObserverAsync<T> : IObserverAsync<T>
     public async ValueTask DisposeAsync()
     {
         Task? allOnSomethingCallsCompleted = null;
-        lock (_reentrantCallsCount)
+        lock (_gate)
         {
             if (_disposeCts.IsCancellationRequested)
             {
@@ -204,16 +212,16 @@ public abstract class ObserverAsync<T> : IObserverAsync<T>
     /// Attempts to enter a notification call, checking for disposal, cancellation, and concurrent access.
     /// </summary>
     /// <param name="cancellationToken">The caller-supplied cancellation token.</param>
-    /// <param name="linkedCts">When successful, a linked <see cref="CancellationTokenSource"/> combining the caller token and disposal token.</param>
+    /// <param name="scope">When successful, a <see cref="LinkedTokenScope"/> providing the effective cancellation token.</param>
     /// <returns><see langword="true"/> if the call was entered successfully; otherwise, <see langword="false"/>.</returns>
     [DebuggerStepThrough]
-    internal bool TryEnterOnSomethingCall(CancellationToken cancellationToken, [NotNullWhen(true)] out CancellationTokenSource? linkedCts)
+    internal bool TryEnterOnSomethingCall(CancellationToken cancellationToken, out LinkedTokenScope scope)
     {
-        lock (_reentrantCallsCount)
+        lock (_gate)
         {
             if (_disposeCts.IsCancellationRequested || cancellationToken.IsCancellationRequested)
             {
-                linkedCts = null;
+                scope = default;
                 return false;
             }
 
@@ -221,14 +229,24 @@ public abstract class ObserverAsync<T> : IObserverAsync<T>
             if (_callsCount != reentrantCallsCount)
             {
                 UnhandledExceptionHandler.OnUnhandledException(new ConcurrentObserverCallsException());
-                linkedCts = null;
+                scope = default;
                 return false;
             }
 
             _callsCount++;
             _reentrantCallsCount.Value = reentrantCallsCount + 1;
 
-            linkedCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken, _disposeCts.Token);
+            // Avoid allocating a linked CTS when the caller token is None or already the dispose token.
+            if (cancellationToken == CancellationToken.None || cancellationToken == _disposeCts.Token)
+            {
+                scope = new LinkedTokenScope(null, _disposeCts.Token);
+            }
+            else
+            {
+                var linkedCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken, _disposeCts.Token);
+                scope = new LinkedTokenScope(linkedCts, linkedCts.Token);
+            }
+
             return true;
         }
     }
@@ -241,7 +259,7 @@ public abstract class ObserverAsync<T> : IObserverAsync<T>
     [DebuggerStepThrough]
     internal bool ExitOnSomethingCall()
     {
-        lock (_reentrantCallsCount)
+        lock (_gate)
         {
             _callsCount--;
             var reentrantCallsCount = --_reentrantCallsCount.Value;
@@ -321,4 +339,17 @@ public abstract class ObserverAsync<T> : IObserverAsync<T>
     /// <param name="cancellationToken">A cancellation token that can be used to cancel the asynchronous operation.</param>
     /// <returns>A ValueTask that represents the asynchronous operation.</returns>
     protected abstract ValueTask OnNextAsyncCore(T value, CancellationToken cancellationToken);
+
+    /// <summary>
+    /// A lightweight scope that wraps an optional <see cref="CancellationTokenSource"/> and exposes the
+    /// effective <see cref="CancellationToken"/>. When no linked source is needed (e.g. the caller token
+    /// is <see cref="CancellationToken.None"/>), the scope avoids allocating a linked CTS entirely.
+    /// </summary>
+    /// <param name="Cts">The linked CTS to dispose, or <see langword="null"/> if no allocation was needed.</param>
+    /// <param name="Token">The effective cancellation token for the notification call.</param>
+    internal readonly record struct LinkedTokenScope(CancellationTokenSource? Cts, CancellationToken Token) : IDisposable
+    {
+        /// <inheritdoc/>
+        public void Dispose() => Cts?.Dispose();
+    }
 }

--- a/src/ReactiveUI.Extensions/Async/Operators/CombineLatest.cs
+++ b/src/ReactiveUI.Extensions/Async/Operators/CombineLatest.cs
@@ -239,17 +239,9 @@ public static partial class ObservableAsync
         protected override async ValueTask<IAsyncDisposable> SubscribeAsyncCore(IObserverAsync<TResult> observer, CancellationToken cancellationToken)
         {
             var subscription = new CombineLatestSubscription(observer, src1, src2, selector);
-            try
-            {
-                await subscription.SubscribeAsync(cancellationToken);
-            }
-            catch
-            {
-                await subscription.DisposeAsync();
-                throw;
-            }
-
-            return subscription;
+            return await SubscriptionHelper.SubscribeAndDisposeOnFailureAsync(
+                subscription,
+                () => subscription.SubscribeAsync(cancellationToken));
         }
 
         /// <summary>
@@ -494,17 +486,9 @@ public static partial class ObservableAsync
         protected override async ValueTask<IAsyncDisposable> SubscribeAsyncCore(IObserverAsync<TResult> observer, CancellationToken cancellationToken)
         {
             var subscription = new CombineLatestSubscription(observer, src1, src2, src3, selector);
-            try
-            {
-                await subscription.SubscribeAsync(cancellationToken);
-            }
-            catch
-            {
-                await subscription.DisposeAsync();
-                throw;
-            }
-
-            return subscription;
+            return await SubscriptionHelper.SubscribeAndDisposeOnFailureAsync(
+                subscription,
+                () => subscription.SubscribeAsync(cancellationToken));
         }
 
         /// <summary>
@@ -810,17 +794,9 @@ public static partial class ObservableAsync
         protected override async ValueTask<IAsyncDisposable> SubscribeAsyncCore(IObserverAsync<TResult> observer, CancellationToken cancellationToken)
         {
             var subscription = new CombineLatestSubscription(observer, src1, src2, src3, src4, selector);
-            try
-            {
-                await subscription.SubscribeAsync(cancellationToken);
-            }
-            catch
-            {
-                await subscription.DisposeAsync();
-                throw;
-            }
-
-            return subscription;
+            return await SubscriptionHelper.SubscribeAndDisposeOnFailureAsync(
+                subscription,
+                () => subscription.SubscribeAsync(cancellationToken));
         }
 
         /// <summary>
@@ -1187,17 +1163,9 @@ public static partial class ObservableAsync
         protected override async ValueTask<IAsyncDisposable> SubscribeAsyncCore(IObserverAsync<TResult> observer, CancellationToken cancellationToken)
         {
             var subscription = new CombineLatestSubscription(observer, src1, src2, src3, src4, src5, selector);
-            try
-            {
-                await subscription.SubscribeAsync(cancellationToken);
-            }
-            catch
-            {
-                await subscription.DisposeAsync();
-                throw;
-            }
-
-            return subscription;
+            return await SubscriptionHelper.SubscribeAndDisposeOnFailureAsync(
+                subscription,
+                () => subscription.SubscribeAsync(cancellationToken));
         }
 
         /// <summary>
@@ -1625,17 +1593,9 @@ public static partial class ObservableAsync
         protected override async ValueTask<IAsyncDisposable> SubscribeAsyncCore(IObserverAsync<TResult> observer, CancellationToken cancellationToken)
         {
             var subscription = new CombineLatestSubscription(observer, src1, src2, src3, src4, src5, src6, selector);
-            try
-            {
-                await subscription.SubscribeAsync(cancellationToken);
-            }
-            catch
-            {
-                await subscription.DisposeAsync();
-                throw;
-            }
-
-            return subscription;
+            return await SubscriptionHelper.SubscribeAndDisposeOnFailureAsync(
+                subscription,
+                () => subscription.SubscribeAsync(cancellationToken));
         }
 
         /// <summary>
@@ -2124,17 +2084,9 @@ public static partial class ObservableAsync
         protected override async ValueTask<IAsyncDisposable> SubscribeAsyncCore(IObserverAsync<TResult> observer, CancellationToken cancellationToken)
         {
             var subscription = new CombineLatestSubscription(observer, src1, src2, src3, src4, src5, src6, src7, selector);
-            try
-            {
-                await subscription.SubscribeAsync(cancellationToken);
-            }
-            catch
-            {
-                await subscription.DisposeAsync();
-                throw;
-            }
-
-            return subscription;
+            return await SubscriptionHelper.SubscribeAndDisposeOnFailureAsync(
+                subscription,
+                () => subscription.SubscribeAsync(cancellationToken));
         }
 
         /// <summary>
@@ -2684,17 +2636,9 @@ public static partial class ObservableAsync
         protected override async ValueTask<IAsyncDisposable> SubscribeAsyncCore(IObserverAsync<TResult> observer, CancellationToken cancellationToken)
         {
             var subscription = new CombineLatestSubscription(observer, src1, src2, src3, src4, src5, src6, src7, src8, selector);
-            try
-            {
-                await subscription.SubscribeAsync(cancellationToken);
-            }
-            catch
-            {
-                await subscription.DisposeAsync();
-                throw;
-            }
-
-            return subscription;
+            return await SubscriptionHelper.SubscribeAndDisposeOnFailureAsync(
+                subscription,
+                () => subscription.SubscribeAsync(cancellationToken));
         }
 
         /// <summary>

--- a/src/ReactiveUI.Extensions/Async/Operators/CombineLatestEnumerable.cs
+++ b/src/ReactiveUI.Extensions/Async/Operators/CombineLatestEnumerable.cs
@@ -83,17 +83,9 @@ public static partial class ObservableAsync
             }
 
             var subscription = new Subscription(_sources, observer);
-            try
-            {
-                await subscription.SubscribeAsync(cancellationToken);
-            }
-            catch
-            {
-                await subscription.DisposeAsync();
-                throw;
-            }
-
-            return subscription;
+            return await SubscriptionHelper.SubscribeAndDisposeOnFailureAsync(
+                subscription,
+                () => subscription.SubscribeAsync(cancellationToken));
         }
 
         /// <summary>

--- a/src/ReactiveUI.Extensions/Async/Operators/ConcatEnumerableObservable{T}.cs
+++ b/src/ReactiveUI.Extensions/Async/Operators/ConcatEnumerableObservable{T}.cs
@@ -35,17 +35,9 @@ internal sealed class ConcatEnumerableObservable<T>(IEnumerable<IObservableAsync
     protected override async ValueTask<IAsyncDisposable> SubscribeAsyncCore(IObserverAsync<T> observer, CancellationToken cancellationToken)
     {
         var subscription = new ConcatEnumerableSubscription(this, observer);
-        try
-        {
-            await subscription.SubscribeNextAsync();
-        }
-        catch
-        {
-            await subscription.DisposeAsync();
-            throw;
-        }
-
-        return subscription;
+        return await SubscriptionHelper.SubscribeAndDisposeOnFailureAsync(
+            subscription,
+            subscription.SubscribeNextAsync);
     }
 
     /// <summary>

--- a/src/ReactiveUI.Extensions/Async/Operators/ConcatObservablesObservable{T}.cs
+++ b/src/ReactiveUI.Extensions/Async/Operators/ConcatObservablesObservable{T}.cs
@@ -25,17 +25,9 @@ internal sealed class ConcatObservablesObservable<T>(IObservableAsync<IObservabl
     protected override async ValueTask<IAsyncDisposable> SubscribeAsyncCore(IObserverAsync<T> observer, CancellationToken cancellationToken)
     {
         var subscription = new ConcatSubscription(observer);
-        try
-        {
-            await subscription.SubscribeAsync(source, cancellationToken);
-        }
-        catch
-        {
-            await subscription.DisposeAsync();
-            throw;
-        }
-
-        return subscription;
+        return await SubscriptionHelper.SubscribeAndDisposeOnFailureAsync(
+            subscription,
+            () => subscription.SubscribeAsync(source, cancellationToken));
     }
 
     /// <summary>

--- a/src/ReactiveUI.Extensions/Async/Operators/GroupBy.cs
+++ b/src/ReactiveUI.Extensions/Async/Operators/GroupBy.cs
@@ -26,7 +26,7 @@ public static partial class ObservableAsync
         /// <typeparam name="TKey">The type of the key returned by the key selector function. Must be non-nullable.</typeparam>
         /// <param name="keySelector">A function to extract the key for each element in the source sequence.</param>
         /// <returns>An asynchronous observable sequence of grouped observables, each containing elements that share a common key.</returns>
-        /// <exception cref="ArgumentNullException">Thrown if <paramref name="source"/> or <paramref name="keySelector"/> is null.</exception>
+        /// <exception cref="ArgumentNullException">Thrown if <paramref name="keySelector"/> is null.</exception>
         public IObservableAsync<GroupedAsyncObservable<TKey, TValue>> GroupBy<TKey>(Func<TValue, TKey> keySelector)
         where TKey : notnull
         {
@@ -50,7 +50,7 @@ public static partial class ObservableAsync
         /// within each group.</param>
         /// <returns>An asynchronous observable sequence containing grouped observables, each representing a collection of elements
         /// that share a common key.</returns>
-        /// <exception cref="ArgumentNullException">Thrown if <paramref name="source"/> or <paramref name="keySelector"/> is null.</exception>
+        /// <exception cref="ArgumentNullException">Thrown if <paramref name="keySelector"/> is null.</exception>
         public IObservableAsync<GroupedAsyncObservable<TKey, TValue>> GroupBy<TKey>(Func<TValue, TKey> keySelector, Func<TKey, ISubjectAsync<TValue>> groupSubjectSelector)
             where TKey : notnull
         {
@@ -99,14 +99,14 @@ public static partial class ObservableAsync
         /// <returns>An async disposable that tears down the subscription when disposed.</returns>
         protected override async ValueTask<IAsyncDisposable> SubscribeAsyncCore(IObserverAsync<GroupedAsyncObservable<TKey, TValue>> observer, CancellationToken cancellationToken)
         {
-            var subscrption = new Subscription(this, observer);
+            var subscription = new Subscription(this, observer);
             try
             {
-                return await subscrption.SubscribeAsync(cancellationToken);
+                return await subscription.SubscribeAsync(cancellationToken);
             }
             catch
             {
-                await subscrption.DisposeAsync();
+                await subscription.DisposeAsync();
                 throw;
             }
         }

--- a/src/ReactiveUI.Extensions/Async/Operators/Merge.cs
+++ b/src/ReactiveUI.Extensions/Async/Operators/Merge.cs
@@ -81,17 +81,9 @@ public static partial class ObservableAsync
         protected override async ValueTask<IAsyncDisposable> SubscribeAsyncCore(IObserverAsync<T> observer, CancellationToken cancellationToken)
         {
             var subscription = new MergeSubscription<T>(observer);
-            try
-            {
-                await subscription.SubscribeAsync(sources, cancellationToken);
-            }
-            catch
-            {
-                await subscription.DisposeAsync();
-                throw;
-            }
-
-            return subscription;
+            return await SubscriptionHelper.SubscribeAndDisposeOnFailureAsync(
+                subscription,
+                () => subscription.SubscribeAsync(sources, cancellationToken));
         }
     }
 
@@ -105,17 +97,9 @@ public static partial class ObservableAsync
         protected override async ValueTask<IAsyncDisposable> SubscribeAsyncCore(IObserverAsync<T> observer, CancellationToken cancellationToken)
         {
             var subscription = new MergeSubscriptionWithMaxConcurrency<T>(observer, maxConcurrent);
-            try
-            {
-                await subscription.SubscribeAsync(sources, cancellationToken);
-            }
-            catch
-            {
-                await subscription.DisposeAsync();
-                throw;
-            }
-
-            return subscription;
+            return await SubscriptionHelper.SubscribeAndDisposeOnFailureAsync(
+                subscription,
+                () => subscription.SubscribeAsync(sources, cancellationToken));
         }
     }
 

--- a/src/ReactiveUI.Extensions/Async/Operators/SwitchObservable.cs
+++ b/src/ReactiveUI.Extensions/Async/Operators/SwitchObservable.cs
@@ -25,17 +25,9 @@ internal sealed class SwitchObservable<T>(IObservableAsync<IObservableAsync<T>> 
     protected override async ValueTask<IAsyncDisposable> SubscribeAsyncCore(IObserverAsync<T> observer, CancellationToken cancellationToken)
     {
         var subscription = new SwitchSubscription(observer);
-        try
-        {
-            await subscription.SubscribeAsync(source, cancellationToken);
-        }
-        catch
-        {
-            await subscription.DisposeAsync();
-            throw;
-        }
-
-        return subscription;
+        return await SubscriptionHelper.SubscribeAndDisposeOnFailureAsync(
+            subscription,
+            () => subscription.SubscribeAsync(source, cancellationToken));
     }
 
     /// <summary>

--- a/src/ReactiveUI.Extensions/Async/Operators/TakeUntil.cs
+++ b/src/ReactiveUI.Extensions/Async/Operators/TakeUntil.cs
@@ -135,16 +135,9 @@ public static partial class ObservableAsync
         protected override async ValueTask<IAsyncDisposable> SubscribeAsyncCore(IObserverAsync<T> observer, CancellationToken cancellationToken)
         {
             var subscription = new TakeUntilPredicateSubscription(this, observer);
-            try
-            {
-                await subscription.SubscribeAsync(cancellationToken);
-                return subscription;
-            }
-            catch
-            {
-                await subscription.DisposeAsync();
-                throw;
-            }
+            return await SubscriptionHelper.SubscribeAndDisposeOnFailureAsync(
+                subscription,
+                () => subscription.SubscribeAsync(cancellationToken));
         }
 
         /// <summary>
@@ -208,16 +201,9 @@ public static partial class ObservableAsync
         protected override async ValueTask<IAsyncDisposable> SubscribeAsyncCore(IObserverAsync<T> observer, CancellationToken cancellationToken)
         {
             var subscription = new Subscription(this, observer);
-            try
-            {
-                await subscription.SubscribeAsync(cancellationToken);
-                return subscription;
-            }
-            catch
-            {
-                await subscription.DisposeAsync();
-                throw;
-            }
+            return await SubscriptionHelper.SubscribeAndDisposeOnFailureAsync(
+                subscription,
+                () => subscription.SubscribeAsync(cancellationToken));
         }
 
         /// <summary>
@@ -374,16 +360,9 @@ public static partial class ObservableAsync
         protected override async ValueTask<IAsyncDisposable> SubscribeAsyncCore(IObserverAsync<T> observer, CancellationToken cancellationToken)
         {
             var subscription = new Subscription(this, observer);
-            try
-            {
-                await subscription.SubscribeAsync(cancellationToken);
-                return subscription;
-            }
-            catch
-            {
-                await subscription.DisposeAsync();
-                throw;
-            }
+            return await SubscriptionHelper.SubscribeAndDisposeOnFailureAsync(
+                subscription,
+                () => subscription.SubscribeAsync(cancellationToken));
         }
 
         /// <summary>
@@ -587,16 +566,9 @@ public static partial class ObservableAsync
         protected override async ValueTask<IAsyncDisposable> SubscribeAsyncCore(IObserverAsync<T> observer, CancellationToken cancellationToken)
         {
             var subscription = new Subscription(this, observer);
-            try
-            {
-                await subscription.SubscribeAsync(cancellationToken);
-                return subscription;
-            }
-            catch
-            {
-                await subscription.DisposeAsync();
-                throw;
-            }
+            return await SubscriptionHelper.SubscribeAndDisposeOnFailureAsync(
+                subscription,
+                () => subscription.SubscribeAsync(cancellationToken));
         }
 
         /// <summary>
@@ -768,16 +740,9 @@ public static partial class ObservableAsync
         protected override async ValueTask<IAsyncDisposable> SubscribeAsyncCore(IObserverAsync<T> observer, CancellationToken cancellationToken)
         {
             var subscription = new Subscription(this, observer);
-            try
-            {
-                await subscription.SubscribeAsync(cancellationToken);
-                return subscription;
-            }
-            catch
-            {
-                await subscription.DisposeAsync();
-                throw;
-            }
+            return await SubscriptionHelper.SubscribeAndDisposeOnFailureAsync(
+                subscription,
+                async () => { await subscription.SubscribeAsync(cancellationToken); });
         }
 
         /// <summary>
@@ -956,16 +921,9 @@ public static partial class ObservableAsync
         protected override async ValueTask<IAsyncDisposable> SubscribeAsyncCore(IObserverAsync<T> observer, CancellationToken cancellationToken)
         {
             var subscription = new TakeUntilAsyncPredicateSubscription(this, observer);
-            try
-            {
-                await subscription.SubscribeAsync(cancellationToken);
-                return subscription;
-            }
-            catch
-            {
-                await subscription.DisposeAsync();
-                throw;
-            }
+            return await SubscriptionHelper.SubscribeAndDisposeOnFailureAsync(
+                subscription,
+                () => subscription.SubscribeAsync(cancellationToken));
         }
 
         /// <summary>

--- a/src/ReactiveUI.Extensions/Async/Subjects/Base/BaseReplayLatestSubjectAsync.cs
+++ b/src/ReactiveUI.Extensions/Async/Subjects/Base/BaseReplayLatestSubjectAsync.cs
@@ -33,7 +33,7 @@ public abstract class BaseReplayLatestSubjectAsync<T>(Optional<T> startValue) : 
     /// <summary>
     /// The immutable list of currently subscribed observers.
     /// </summary>
-    private ImmutableList<IObserverAsync<T>> _observers = [];
+    private ImmutableArray<IObserverAsync<T>> _observers = [];
 
     /// <summary>
     /// The completion result, or <see langword="null"/> if the subject has not yet completed.
@@ -54,7 +54,7 @@ public abstract class BaseReplayLatestSubjectAsync<T>(Optional<T> startValue) : 
     /// <returns>A task that represents the asynchronous notification operation.</returns>
     public async ValueTask OnNextAsync(T value, CancellationToken cancellationToken)
     {
-        ImmutableList<IObserverAsync<T>> observers;
+        ImmutableArray<IObserverAsync<T>> observers;
         using (await _gate.LockAsync())
         {
             if (_result is not null)
@@ -79,7 +79,7 @@ public abstract class BaseReplayLatestSubjectAsync<T>(Optional<T> startValue) : 
     /// <returns>A task that represents the asynchronous notification operation.</returns>
     public async ValueTask OnErrorResumeAsync(Exception error, CancellationToken cancellationToken)
     {
-        ImmutableList<IObserverAsync<T>> observers;
+        ImmutableArray<IObserverAsync<T>> observers;
         using (await _gate.LockAsync())
         {
             if (_result is not null)
@@ -103,7 +103,7 @@ public abstract class BaseReplayLatestSubjectAsync<T>(Optional<T> startValue) : 
     /// been notified.</returns>
     public ValueTask OnCompletedAsync(Result result)
     {
-        ImmutableList<IObserverAsync<T>>? observers;
+        ImmutableArray<IObserverAsync<T>> observers;
         lock (_gate)
         {
             if (_result is not null)

--- a/src/ReactiveUI.Extensions/Async/Subjects/Base/BaseStatelessReplayLastSubjectAsync.cs
+++ b/src/ReactiveUI.Extensions/Async/Subjects/Base/BaseStatelessReplayLastSubjectAsync.cs
@@ -41,7 +41,7 @@ public abstract class BaseStatelessReplayLastSubjectAsync<T>(Optional<T> startVa
     /// <summary>
     /// The immutable list of currently subscribed observers.
     /// </summary>
-    private ImmutableList<IObserverAsync<T>> _observers = [];
+    private ImmutableArray<IObserverAsync<T>> _observers = [];
 
     /// <summary>
     /// Gets an observable sequence that represents the asynchronous values published by the subject.
@@ -56,7 +56,7 @@ public abstract class BaseStatelessReplayLastSubjectAsync<T>(Optional<T> startVa
     /// <returns>A task that represents the asynchronous notification operation.</returns>
     public async ValueTask OnNextAsync(T value, CancellationToken cancellationToken)
     {
-        ImmutableList<IObserverAsync<T>> observers;
+        ImmutableArray<IObserverAsync<T>> observers;
         using (await _gate.LockAsync())
         {
             _value = new(value);
@@ -77,7 +77,7 @@ public abstract class BaseStatelessReplayLastSubjectAsync<T>(Optional<T> startVa
     /// <returns>A task that represents the asynchronous error notification operation.</returns>
     public async ValueTask OnErrorResumeAsync(Exception error, CancellationToken cancellationToken)
     {
-        ImmutableList<IObserverAsync<T>> observers;
+        ImmutableArray<IObserverAsync<T>> observers;
         using (await _gate.LockAsync())
         {
             observers = _observers;
@@ -95,7 +95,7 @@ public abstract class BaseStatelessReplayLastSubjectAsync<T>(Optional<T> startVa
     /// <returns>A task that represents the asynchronous notification operation.</returns>
     public async ValueTask OnCompletedAsync(Result result)
     {
-        ImmutableList<IObserverAsync<T>> observers;
+        ImmutableArray<IObserverAsync<T>> observers;
         using (await _gate.LockAsync())
         {
             observers = _observers;
@@ -138,7 +138,7 @@ public abstract class BaseStatelessReplayLastSubjectAsync<T>(Optional<T> startVa
             using (await _gate.LockAsync())
             {
                 _observers = _observers.Remove(observer);
-                if (_observers.Count == 0)
+                if (_observers.IsEmpty)
                 {
                     _value = _startValue;
                 }

--- a/src/ReactiveUI.Extensions/Async/Subjects/Base/BaseStatelessSubjectAsync.cs
+++ b/src/ReactiveUI.Extensions/Async/Subjects/Base/BaseStatelessSubjectAsync.cs
@@ -21,9 +21,9 @@ namespace ReactiveUI.Extensions.Async.Subjects;
 public abstract class BaseStatelessSubjectAsync<T> : ObservableAsync<T>, ISubjectAsync<T>
 {
     /// <summary>
-    /// The immutable list of currently subscribed observers.
+    /// The immutable array of currently subscribed observers.
     /// </summary>
-    private ImmutableList<IObserverAsync<T>> _observers = [];
+    private ImmutableArray<IObserverAsync<T>> _observers = [];
 
     /// <summary>
     /// Gets an observable sequence that represents the current and future values of the subject.
@@ -40,7 +40,7 @@ public abstract class BaseStatelessSubjectAsync<T> : ObservableAsync<T>, ISubjec
     /// <param name="cancellationToken">A cancellation token that can be used to cancel the notification operation.</param>
     /// <returns>A ValueTask that represents the asynchronous notification operation.</returns>
     public ValueTask OnNextAsync(T value, CancellationToken cancellationToken) =>
-        OnNextAsyncCore(Volatile.Read(ref _observers), value, cancellationToken);
+        OnNextAsyncCore(_observers, value, cancellationToken);
 
     /// <summary>
     /// Handles an error by resuming the asynchronous operation, allowing observers to continue receiving notifications
@@ -50,14 +50,14 @@ public abstract class BaseStatelessSubjectAsync<T> : ObservableAsync<T>, ISubjec
     /// <param name="cancellationToken">A cancellation token that can be used to cancel the resume operation.</param>
     /// <returns>A ValueTask that represents the asynchronous resume operation.</returns>
     public ValueTask OnErrorResumeAsync(Exception error, CancellationToken cancellationToken) =>
-        OnErrorResumeAsyncCore(Volatile.Read(ref _observers), error, cancellationToken);
+        OnErrorResumeAsyncCore(_observers, error, cancellationToken);
 
     /// <summary>
     /// Notifies all registered observers that the operation has completed and provides the final result asynchronously.
     /// </summary>
     /// <param name="result">The result to deliver to observers upon completion. Cannot be null.</param>
     /// <returns>A ValueTask that represents the asynchronous notification operation.</returns>
-    public ValueTask OnCompletedAsync(Result result) => OnCompletedAsyncCore(Volatile.Read(ref _observers), result);
+    public ValueTask OnCompletedAsync(Result result) => OnCompletedAsyncCore(_observers, result);
 
     /// <summary>
     /// Asynchronously releases resources used by the current instance.
@@ -67,7 +67,7 @@ public abstract class BaseStatelessSubjectAsync<T> : ObservableAsync<T>, ISubjec
     /// <returns>A ValueTask that represents the asynchronous dispose operation.</returns>
     public ValueTask DisposeAsync()
     {
-        Volatile.Write(ref _observers, ImmutableList<IObserverAsync<T>>.Empty);
+        ImmutableInterlocked.Update(ref _observers, static observers => observers.Clear());
         GC.SuppressFinalize(this);
         return default;
     }

--- a/src/ReactiveUI.Extensions/Async/Subjects/Base/BaseSubjectAsync.cs
+++ b/src/ReactiveUI.Extensions/Async/Subjects/Base/BaseSubjectAsync.cs
@@ -31,7 +31,7 @@ public abstract class BaseSubjectAsync<T> : ObservableAsync<T>, ISubjectAsync<T>
     /// <summary>
     /// The immutable list of currently subscribed observers.
     /// </summary>
-    private ImmutableList<IObserverAsync<T>> _observers = [];
+    private ImmutableArray<IObserverAsync<T>> _observers = [];
 
     /// <summary>
     /// The completion result, or <see langword="null"/> if the subject has not yet completed.
@@ -54,7 +54,7 @@ public abstract class BaseSubjectAsync<T> : ObservableAsync<T>, ISubjectAsync<T>
     /// <returns>A ValueTask that represents the asynchronous notification operation.</returns>
     public ValueTask OnNextAsync(T value, CancellationToken cancellationToken)
     {
-        ImmutableList<IObserverAsync<T>>? observers;
+        ImmutableArray<IObserverAsync<T>> observers;
 
         lock (_gate)
         {
@@ -79,7 +79,7 @@ public abstract class BaseSubjectAsync<T> : ObservableAsync<T>, ISubjectAsync<T>
     /// <returns>A ValueTask that represents the asynchronous operation of notifying observers of the error.</returns>
     public ValueTask OnErrorResumeAsync(Exception error, CancellationToken cancellationToken)
     {
-        ImmutableList<IObserverAsync<T>>? observers;
+        ImmutableArray<IObserverAsync<T>> observers;
 
         lock (_gate)
         {
@@ -104,7 +104,7 @@ public abstract class BaseSubjectAsync<T> : ObservableAsync<T>, ISubjectAsync<T>
     /// been notified.</returns>
     public ValueTask OnCompletedAsync(Result result)
     {
-        ImmutableList<IObserverAsync<T>>? observers;
+        ImmutableArray<IObserverAsync<T>> observers;
         lock (_gate)
         {
             if (_result is not null)

--- a/src/ReactiveUI.Extensions/Async/Subjects/Base/Concurrent.cs
+++ b/src/ReactiveUI.Extensions/Async/Subjects/Base/Concurrent.cs
@@ -33,12 +33,24 @@ public static class Concurrent
     {
         ArgumentExceptionHelper.ThrowIfNull(observers, nameof(observers));
 
-        if (observers.Count == 0)
+        var count = observers.Count;
+        if (count == 0)
         {
             return default;
         }
 
-        return new ValueTask(Task.WhenAll(observers.Select(x => x.OnNextAsync(value, cancellationToken).AsTask())));
+        if (count == 1)
+        {
+            return observers[0].OnNextAsync(value, cancellationToken);
+        }
+
+        var tasks = new Task[count];
+        for (var i = 0; i < count; i++)
+        {
+            tasks[i] = observers[i].OnNextAsync(value, cancellationToken).AsTask();
+        }
+
+        return new ValueTask(Task.WhenAll(tasks));
     }
 
     /// <summary>
@@ -59,12 +71,24 @@ public static class Concurrent
     {
         ArgumentExceptionHelper.ThrowIfNull(observers, nameof(observers));
 
-        if (observers.Count == 0)
+        var count = observers.Count;
+        if (count == 0)
         {
             return default;
         }
 
-        return new ValueTask(Task.WhenAll(observers.Select(x => x.OnErrorResumeAsync(error, cancellationToken).AsTask())));
+        if (count == 1)
+        {
+            return observers[0].OnErrorResumeAsync(error, cancellationToken);
+        }
+
+        var tasks = new Task[count];
+        for (var i = 0; i < count; i++)
+        {
+            tasks[i] = observers[i].OnErrorResumeAsync(error, cancellationToken).AsTask();
+        }
+
+        return new ValueTask(Task.WhenAll(tasks));
     }
 
     /// <summary>
@@ -85,11 +109,23 @@ public static class Concurrent
     {
         ArgumentExceptionHelper.ThrowIfNull(observers, nameof(observers));
 
-        if (observers.Count == 0)
+        var count = observers.Count;
+        if (count == 0)
         {
             return default;
         }
 
-        return new ValueTask(Task.WhenAll(observers.Select(x => x.OnCompletedAsync(result).AsTask())));
+        if (count == 1)
+        {
+            return observers[0].OnCompletedAsync(result);
+        }
+
+        var tasks = new Task[count];
+        for (var i = 0; i < count; i++)
+        {
+            tasks[i] = observers[i].OnCompletedAsync(result).AsTask();
+        }
+
+        return new ValueTask(Task.WhenAll(tasks));
     }
 }

--- a/src/ReactiveUI.Extensions/ReactiveExtensions.cs
+++ b/src/ReactiveUI.Extensions/ReactiveExtensions.cs
@@ -126,7 +126,11 @@ public static class ReactiveExtensions
             ? source.Publish(shared => shared.Buffer(() => shared.Throttle(idleTime)))
             : Observable.Create<IList<T>>(observer =>
             {
+#if NET9_0_OR_GREATER
+                Lock gate = new();
+#else
                 object gate = new();
+#endif
                 List<T> buffer = new();
                 SerialDisposable timer = new();
 
@@ -472,15 +476,8 @@ public static class ReactiveExtensions
     /// <param name="events">Values to push.</param>
     public static void OnNext<T>(this IObserver<T> observer, params T[] events)
     {
-        if (observer == null)
-        {
-            throw new ArgumentNullException(nameof(observer));
-        }
-
-        if (events == null)
-        {
-            throw new ArgumentNullException(nameof(events));
-        }
+        ArgumentExceptionHelper.ThrowIfNull(observer, nameof(observer));
+        ArgumentExceptionHelper.ThrowIfNull(events, nameof(events));
 
         FastForEach(observer, events);
     }


### PR DESCRIPTION
## What's changed for end users

This release targets the core notification pipeline — every value flowing through any async operator hits `ObserverAsync.TryEnterOnSomethingCall` and `Concurrent.Forward*`. These changes reduce per-notification allocations significantly:

- **~200 bytes saved per notification** when the caller's cancellation token is `None` or matches the dispose token (the common case for `OnCompleted` and most `OnNext` calls). Previously a `CancellationTokenSource.CreateLinkedTokenSource` was allocated on every single call.
- **Zero-allocation single-observer fast path** for concurrent subjects — the most common case (1 subscriber) now avoids `Task[]`, `Task.WhenAll`, LINQ iterator, and closure allocations entirely.
- **ImmutableArray replaces ImmutableList** for observer tracking in all 4 subject base classes — flat array instead of balanced binary tree, better cache locality at typical observer counts (1–5).
- **Async state machine removed** from `ObservableAsync.SubscribeAsync` — was wrapping a single await for no reason.

No public API changes. No behavior changes. Drop-in upgrade.

---

## Summary

**ObserverAsync — the hottest path in the library:**
- Introduce `LinkedTokenScope` record struct to avoid `CancellationTokenSource.CreateLinkedTokenSource` allocation (~200 bytes) on every `OnNext`/`OnError`/`OnCompleted` when the caller token is `None` or already the dispose token
- Replace locking on `AsyncLocal<int>` with a dedicated gate field using `System.Threading.Lock` on NET9+

**Concurrent subject forwarding:**
- Replace LINQ `.Select().AsTask()` with manual for-loop over pre-sized `Task[]` in all three `Forward*Concurrently` methods, eliminating iterator, closure, and Task wrapper allocations per observer per emission
- Add single-observer fast path that returns the `ValueTask` directly without any `Task[]` or `Task.WhenAll` overhead

**ObservableAsync.SubscribeAsync:**
- Remove unnecessary async state machine — was only awaiting a single call and returning the result

**CompositeDisposableAsync.Clear:**
- Replace LINQ `.Take(clearCount)` with index-bounded for-loop to eliminate enumerator allocation

**Subject base classes** (BaseSubjectAsync, BaseReplayLatestSubjectAsync, BaseStatelessSubjectAsync, BaseStatelessReplayLastSubjectAsync):
- Convert `ImmutableList<IObserverAsync<T>>` → `ImmutableArray<IObserverAsync<T>>` for lower overhead and better cache locality at typical observer counts (1–5)

**Operator subscription safety:**
- Extract `SubscriptionHelper.SubscribeAndDisposeOnFailureAsync` to consolidate the try/catch/dispose/throw pattern from ~20 call sites across CombineLatest arities, TakeUntil variants, Merge, Switch, Concat into one directly-tested internal helper

**Modernization:**
- Seal `AsyncGate`, simplify dispose pattern
- File-scoped namespace for `WrappedObserverAsync`
- Consistent `ArgumentExceptionHelper.ThrowIfNull` usage in `DisposableAsync` and `ReactiveExtensions`
- NET9 `Lock` conditional for `BufferUntilIdle` gate
- Fix CS1734 XML doc warning in `GroupBy`

## Test plan

- [x] `dotnet build ReactiveUI.Extensions.slnx -c Release` — 0 errors, only pre-existing SA1201 warnings from `extension<T>` syntax
- [x] `dotnet test --solution ReactiveUI.Extensions.slnx -c Release` — 3780 tests pass across net8.0/net9.0/net10.0 (0 failures)
- [x] Branch coverage 95.34% → 97.68% (57 new tests covering multi-observer concurrent subjects, terminal operator failure paths, subscription helper, operator error propagation, disposal edge cases, factory validation)

🤖 Generated with [Claude Code](https://claude.com/claude-code)