### PR TITLE
ci+test: lift testTimeout to 15m and tighten 5s subscribe-loop wait

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -22,6 +22,11 @@ jobs:
             installWorkloads: true
             versioningTool: minver
             minverMinimumMajorMinor: '2.3'
-            testTimeout: '8m'
+            # 15m, not 8m: the entire test assembly is serialized via
+            # [assembly: NotInParallel(nameof(UnhandledExceptionHandler))] because the
+            # global unhandled-exception handler is mutable static. On Windows net10 the
+            # MTP/TUnit per-test overhead is ~17x net8/9, so even though net8/9 finish in
+            # ~29s the same suite needs ~8-12m on Windows net10. 15m leaves headroom.
+            testTimeout: '15m'
         secrets:
             CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -32,6 +32,8 @@ jobs:
             # CombineLatestEnumerable.cs (10 chars after the prefix) won't match either pattern.
             sonarCpdExclusions: '**/tests/**,**/tools/**,**/benchmarks/**,**/CombineLatest?.cs,**/CombineLatest??.cs'
             sonarTestExclusions: '**/tests/**,**/tools/**,**/benchmarks/**'
-            testTimeout: '8m'
+            # See ci-build.yml for rationale: net10 + Windows + assembly-wide
+            # NotInParallel(UnhandledExceptionHandler) needs more than 8m.
+            testTimeout: '15m'
         secrets:
             SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}

--- a/src/tests/ReactiveUI.Extensions.Tests/Async/CombineLatestOperatorTests.EnumerableRest.cs
+++ b/src/tests/ReactiveUI.Extensions.Tests/Async/CombineLatestOperatorTests.EnumerableRest.cs
@@ -334,7 +334,11 @@ public partial class CombineLatestOperatorTests
         var normalSource = new DirectSource<int>();
         IObservableAsync<int>[] sources = [slowSource, normalSource];
 
-        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(WaitTimeoutSeconds));
+        // Cancel after 1s, not WaitTimeoutSeconds (5s): this test pure-waits for cancellation
+        // by design (nothing ever sets disposeTrigger) — the cancellation is the only exit,
+        // so we want the shortest window that reliably lets the subscribe loop start. 1s is
+        // safe even on slow CI runners.
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(1));
 
         try
         {


### PR DESCRIPTION
<!-- Please be sure to read our [Contribute guide](https://www.reactiveui.net/contribute/index.html) before opening a PR. -->

## What kind of change does this PR introduce?

CI fix + small test tightening. Targets the test-failure on `main`:
https://github.com/reactiveui/Extensions/actions/runs/26017387908/job/76470433914

## What is the current behavior?

The Windows `net10` leg of the test suite hits the 8m `testTimeout` and is killed by the runner:

> `D:\a\Extensions\Extensions\src\tests\ReactiveUI.Extensions.Tests\bin\Release\net10.0\ReactiveUI.Extensions.Tests.dll (net10.0|x64) failed (8m 29s 991ms)`

On the same runner `net8` and `net9` finish in ~29s. No individual test asserts a failure — every test that runs passes — but the suite as a whole does not fit in the budget.

Root cause is structural, not a real test bug:

- `[assembly: NotInParallel(nameof(UnhandledExceptionHandler))]` in `AssemblyAttributes.cs` serializes all 1,363 tests, because the global `UnhandledExceptionHandler` is mutable static and concurrent `Register` calls would race the save/restore in `UnhandledExceptionTestExecutor`.
- On Windows `net10` the MTP/TUnit per-test overhead is roughly 17× the `net8`/`net9` cost — `net8` averages ~21 ms/test, `net10` averages ~370 ms/test. An 8m budget no longer fits even though Linux runs comfortably.
- `WhenCombineLatestEnumerableDisposedDuringSubscribeLoop_ThenReturnsEarly` pure-waits for cancellation by design (nothing ever sets `disposeTrigger`) — currently 5s × 3 TFMs = 15s wasted on a test that just needs the subscribe loop to start.

## What is the new behavior?

- `testTimeout` raised from `'8m'` to `'15m'` in both `.github/workflows/ci-build.yml` and `.github/workflows/sonarcloud.yml`, with an inline comment explaining the serialization constraint so the value is not 'optimised' back down without context.
- `WhenCombineLatestEnumerableDisposedDuringSubscribeLoop_ThenReturnsEarly` now uses a literal `TimeSpan.FromSeconds(1)` for its cancellation source instead of `WaitTimeoutSeconds` (= 5s). The literal is local to this test only — `WaitTimeoutSeconds` is shared with tests that legitimately need a generous window, so the constant is left at 5s.

Local run on Linux: the modified test now passes in ~1.6s per TFM (was ~5s), saving ~10-12s of pure wall-clock across the three TFMs.

## What might this PR break?

Nothing structurally. The longer `testTimeout` only changes the upper bound — fast runs are unaffected. The 1s cancellation timeout on the subscribe-loop test is well above the time needed for the loop to start (the test asserts an `OperationCanceledException` is observed, nothing time-sensitive). If a future change ever makes `SubscribeAsync` take more than 1s to start subscribing under normal load, the test would false-fail — but that itself would be a bug worth catching.

## Checklist
- [x] I have read the [Contribute guide](https://www.reactiveui.net/contribute/index.html)
- [x] Tests have been added or updated (for bug fixes / features)
- [ ] Docs have been added or updated (for bug fixes / features) — N/A
- [x] Changes target the \`main\` branch
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/)

## Additional information

Diff is +14 / -3 across two workflow files and one test file. No production code touched.