### PR TITLE
test: cap per-test runtime at 60s so a single hang fails its own test

### DIFF
--- a/src/tests/ReactiveUI.Extensions.Tests/GlobalTestSetup.cs
+++ b/src/tests/ReactiveUI.Extensions.Tests/GlobalTestSetup.cs
@@ -1,0 +1,25 @@
+// Copyright (c) 2019-2026 ReactiveUI Association Incorporated. All rights reserved.
+// ReactiveUI Association Incorporated licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+namespace ReactiveUI.Extensions.Tests;
+
+/// <summary>
+/// Configures assembly-wide TUnit defaults via a <see cref="HookType.TestDiscovery"/> hook so they
+/// are in place before any test executes.
+/// </summary>
+internal static class GlobalTestSetup
+{
+    /// <summary>
+    /// Caps every test at 60 seconds. Without a default cap, a single flaky test that hangs
+    /// stalls the entire assembly (the whole suite is serialised via
+    /// <c>[assembly: NotInParallel(nameof(UnhandledExceptionHandler))]</c>) and we lose the
+    /// per-test failure signal — the CI just reports the workflow-level timeout. 60s is far
+    /// above every legitimate test (slowest non-cancellation test is ~5s) so any future hang
+    /// fails its own test with a clear message instead of killing the whole run.
+    /// </summary>
+    /// <param name="context">The TUnit test-discovery context exposing programmatic settings.</param>
+    [Before(HookType.TestDiscovery)]
+    public static void ConfigureDefaults(BeforeTestDiscoveryContext context) =>
+        context.Settings.Timeouts.DefaultTestTimeout = TimeSpan.FromSeconds(60);
+}


### PR DESCRIPTION
<!-- Please be sure to read our [Contribute guide](https://www.reactiveui.net/contribute/index.html) before opening a PR. -->

## What kind of change does this PR introduce?

Test-infrastructure fix. No production code touched.

Addresses the failure on PR #158: https://github.com/reactiveui/Extensions/actions/runs/26019208954/job/76476321864?pr=158

## What is the current behavior?

CI run 26019208954 hit the workflow \`testTimeout\` twice in one run, even after #157 lifted it to 15m:

- ubuntu \`net8.0\` ran for **15m 30s** and was killed (other TFMs on the same host finished in 22-23s).
- Windows \`net10.0\` ran for **15m 30s** and was killed (other TFMs on the same host finished in 26-27s).

Both legs reported `failed: 0` — no individual test asserted a failure. One randomly-selected TFM per host stalls on what looks like a deadlock somewhere in the \`Merge\` / \`CombineLatest\` test area, never emits another \"passed\" line, and eventually trips the workflow timeout. The other TFMs on the same host complete normally.

Two structural issues amplify the problem:

1. The whole assembly is serialised via `[assembly: NotInParallel(nameof(UnhandledExceptionHandler))]` (the global handler is mutable static; concurrent registers would race the save/restore in `UnhandledExceptionTestExecutor`). One hung test blocks every subsequent test.
2. TUnit ships with no default per-test timeout, so the CI loses the per-test failure signal entirely — we only see \"workflow timed out\" without knowing which test hung.

## What is the new behavior?

New `GlobalTestSetup.cs` registers a `[Before(HookType.TestDiscovery)]` hook that sets `TUnitSettings.Timeouts.DefaultTestTimeout` to 60 seconds. Every legitimate test finishes well under that — the slowest non-cancellation test is ~5s — so the cap doesn't affect normal runs. Any future hang will fail its own test with a clear `\"exceeded timeout\"` message instead of stalling the whole suite, making the flake immediately diagnosable on the next run.

Local validation (Linux): the full 4272-test suite passes in ~19s per TFM.

## What might this PR break?

Nothing under normal conditions. Tests that legitimately need more than 60s would need an explicit `[Timeout(...)]` attribute — there are none in the repo today (the longest test is the 5s `WhenCombineLatestEnumerableDisposedDuringSubscribeLoop_ThenReturnsEarly` which #157 already tightened to 1s).

This does **not** fix the underlying flaky-test deadlock — it makes the next occurrence diagnosable by reporting the exact failing test instead of a workflow timeout. Once CI reports which test exceeded 60s, we can fix the deadlock at its root.

## Checklist
- [x] I have read the [Contribute guide](https://www.reactiveui.net/contribute/index.html)
- [x] Tests have been added or updated (for bug fixes / features)
- [ ] Docs have been added or updated (for bug fixes / features) — N/A
- [x] Changes target the \`main\` branch
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/)

## Additional information

Diff is +25 / 0 in one new file (`GlobalTestSetup.cs`). No workflow or production-code change in this PR.