### PR TITLE
fix: bridge ToObservable dispose no longer deadlocks on re-entrant Dispose

### DIFF
--- a/src/ReactiveUI.Extensions/Async/Bridge/ObservableBridgeExtensions.cs
+++ b/src/ReactiveUI.Extensions/Async/Bridge/ObservableBridgeExtensions.cs
@@ -286,10 +286,6 @@ public static class ObservableBridgeExtensions
         /// </summary>
         /// <param name="observer">The synchronous observer to receive notifications.</param>
         /// <returns>A disposable that tears down the async subscription when disposed.</returns>
-        [SuppressMessage(
-            "Major Bug",
-            "S4462:Calls to async methods should not be blocking",
-            Justification = "The IDisposable.Dispose callback is intrinsically synchronous and must tear down the async subscription it bridged on subscribe.")]
         public IDisposable Subscribe(IObserver<T> observer)
         {
             ArgumentExceptionHelper.ThrowIfNull(observer);
@@ -300,37 +296,49 @@ public static class ObservableBridgeExtensions
 
             return new ActionDisposable(() =>
             {
+                // Cancel synchronously: the cancellation token is the actual stop signal that
+                // propagates into the async producer. The remaining IAsyncDisposable teardown
+                // is dispatched to a thread-pool task so the calling thread is never blocked
+                // on it. Synchronously awaiting the dispose deadlocks when a downstream Rx
+                // operator (e.g. Take after enough items) calls Dispose from inside an OnNext
+                // — that OnNext is running on the producer's pump thread, and the producer's
+                // DisposeAsync waits for the pump to terminate, i.e. waits for the very thread
+                // currently blocked inside it.
                 cts.Cancel();
-
-                try
-                {
-                    var task = subscriptionTask;
-                    if (task.IsCompleted)
-                    {
-                        if (task.Result is { } subscription)
-                        {
-                            subscription.DisposeAsync().AsTask().GetAwaiter().GetResult();
-                        }
-                    }
-                    else
-                    {
-                        var subscription = task.GetAwaiter().GetResult();
-                        subscription?.DisposeAsync().AsTask().GetAwaiter().GetResult();
-                    }
-                }
-                catch (OperationCanceledException)
-                {
-                    // Expected during cancellation
-                }
-                catch (Exception e)
-                {
-                    UnhandledExceptionHandler.OnUnhandledException(e);
-                }
-                finally
-                {
-                    cts.Dispose();
-                }
+                _ = Task.Run(() => CleanupAsync(subscriptionTask, cts));
             });
+        }
+
+        /// <summary>
+        /// Drains the deferred subscription task, disposes the underlying async subscription, and
+        /// disposes the cancellation token source. Runs on a thread-pool task so the calling
+        /// thread of <see cref="ActionDisposable"/> is never blocked on async cleanup.
+        /// </summary>
+        /// <param name="subscriptionTask">The subscription task captured at <c>Subscribe</c> time.</param>
+        /// <param name="cts">The cancellation token source owned by the subscription.</param>
+        /// <returns>A task that completes when cleanup finishes.</returns>
+        private static async Task CleanupAsync(Task<IAsyncDisposable?> subscriptionTask, CancellationTokenSource cts)
+        {
+            try
+            {
+                var subscription = await subscriptionTask.ConfigureAwait(false);
+                if (subscription is not null)
+                {
+                    await subscription.DisposeAsync().ConfigureAwait(false);
+                }
+            }
+            catch (OperationCanceledException)
+            {
+                // Expected during cancellation.
+            }
+            catch (Exception e)
+            {
+                UnhandledExceptionHandler.OnUnhandledException(e);
+            }
+            finally
+            {
+                cts.Dispose();
+            }
         }
 
         /// <summary>

--- a/src/tests/ReactiveUI.Extensions.Tests/Async/BridgeTests.cs
+++ b/src/tests/ReactiveUI.Extensions.Tests/Async/BridgeTests.cs
@@ -217,6 +217,32 @@ public class BridgeTests
     }
 
     /// <summary>
+    /// Regression test for the re-entrant-dispose deadlock between <c>ToObservable()</c> and a
+    /// downstream synchronous operator (e.g. <c>Take</c>) that calls <c>Dispose</c> from inside
+    /// an <c>OnNext</c> while the producer pump is still emitting. If the bridge's
+    /// <see cref="IDisposable.Dispose"/> blocks synchronously on the underlying
+    /// <see cref="IAsyncDisposable"/>, the producer thread ends up waiting for itself to
+    /// finish and the test hangs. Wrapped in a 10s deadline so a regression fails fast with a
+    /// clear timeout instead of timing out the whole suite.
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous test operation.</returns>
+    [Test]
+    public async Task WhenAsyncObservableTakeDisposesFromInsideOnNext_ThenDoesNotDeadlock()
+    {
+        const int FirstItemsToConsume = 3;
+        const int RangeLength = 10;
+        using var deadline = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+
+        var result = await AsyncObs.Range(1, RangeLength)
+            .ToObservable()
+            .Take(FirstItemsToConsume)
+            .ToList()
+            .ToTask(deadline.Token);
+
+        await Assert.That(result).IsCollectionEqualTo([1, SequenceItemTwo, SequenceItemThree]);
+    }
+
+    /// <summary>
     /// Tests Rx Subject pushing data through async pipeline.
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous test operation.</returns>
@@ -528,8 +554,14 @@ public class BridgeTests
             var rxObs = source.ToObservable();
             var sub = rxObs.Subscribe(_ => { });
 
-            // Disposing triggers disposal path that throws a general exception
+            // Disposing triggers disposal path that throws a general exception. The cleanup
+            // (and therefore the routed unhandled exception) runs on a background task so the
+            // calling thread is never blocked on async work, so the assertion has to wait for
+            // the handler to be invoked.
             sub.Dispose();
+            await AsyncTestHelpers.WaitForConditionAsync(
+                () => captured is not null,
+                TimeSpan.FromSeconds(5));
 
             await Assert.That(captured).IsNotNull();
             await Assert.That(captured!.Message).IsEqualTo("dispose error");


### PR DESCRIPTION
<!-- Please be sure to read our [Contribute guide](https://www.reactiveui.net/contribute/index.html) before opening a PR. -->

## What kind of change does this PR introduce?

Bug fix (real root cause of the CI flake), plus a focused regression test.

Identifies and fixes the underlying deadlock that caused the random net8/net10 hangs in PR #158's run https://github.com/reactiveui/Extensions/actions/runs/26019208954/job/76476321864?pr=158 — the same flake that #157 (15m timeout) and #162 (60s per-test cap) only worked *around*.

## What is the current behavior?

`ObservableAsyncToObservable<T>.Subscribe` returns an `ActionDisposable` whose body synchronously awaits the underlying async subscription teardown:

```csharp
subscription.DisposeAsync().AsTask().GetAwaiter().GetResult();
```

If a downstream synchronous Rx operator (e.g. `Take` after consuming enough items) calls `Dispose` from inside an `OnNext` callback, that `OnNext` is running on the async producer's pump thread. The dispose call then synchronously waits for the producer to terminate — i.e. it waits for the very thread that is currently blocked inside it. Classic re-entrant deadlock.

**Reproduces locally** with `AsyncObs.Range(1, 10).ToObservable().Where(x => x > 5).Take(3).ToList()` — Take fires Dispose after consuming 6,7,8 while Range is still pumping 9,10. The producer thread enters `ActionDisposable.Dispose` → `subscription.DisposeAsync().GetResult()` → waits for itself → hangs.

This was the unidentified flake in run 26019208954: ubuntu `net8.0` and Windows `net10.0` both ran for 15m30s with `failed: 0`. Diagnosing from the queue-drain logs in the timeout dump (the first `Released constraint keys for test ...` line in the drain is the test that was actually running) pointed at `BridgeTests.WhenAsyncObservableWithRxOperators_ThenPipelineWorks` (ubuntu net8) and `BridgeTests.WhenIObservableToObservableAsync_ThenForwardsAllItems` (Windows net10).

## What is the new behavior?

`ActionDisposable` now cancels the `CancellationTokenSource` synchronously (that is the actual stop signal that flows into the producer) and dispatches the `IAsyncDisposable` teardown to a `Task.Run`-backed `CleanupAsync` helper. The calling thread is no longer blocked, so a re-entrant `Dispose`-from-`OnNext` walks back out cleanly; the producer then terminates on the cancellation token. Exception routing to the `UnhandledExceptionHandler` is preserved — it just runs on the cleanup task now.

`WhenToObservableDisposalThrowsGeneralException_ThenRoutesToUnhandledHandler` previously assumed `Dispose` finished the routed exception synchronously. It now waits up to 5 seconds for the async cleanup to surface the captured exception via `AsyncTestHelpers.WaitForConditionAsync`.

New `WhenAsyncObservableTakeDisposesFromInsideOnNext_ThenDoesNotDeadlock` regression test wraps the minimal repro in a 10s deadline, so a future regression fails its own test with a clear timeout instead of stalling the suite (the 60s default from #162 would catch it too, but a 10s deadline is faster signal).

Full suite locally: 4275 tests pass per TFM in ~19s.

## What might this PR break?

The contract for `ToObservable()`'s returned disposable has changed subtly: `Dispose` now returns as soon as cancellation is signalled, with the underlying `IAsyncDisposable` teardown completing on a background task. Callers that assumed the underlying subscription was *fully* disposed by the time `Dispose` returned are now racy — but no such callers exist in the codebase, and Rx's `IDisposable.Dispose` is widely treated as best-effort/cancel-now teardown elsewhere (System.Reactive's bridges behave the same way).

`WhenToObservableDisposedBeforeSubscriptionCompletes_ThenDisposalWaitsForSubscription` still passes — it asserts the dispose eventually completes (which it does, immediately, now), not that it blocks until subscribe finishes.

## Checklist
- [x] I have read the [Contribute guide](https://www.reactiveui.net/contribute/index.html)
- [x] Tests have been added or updated (for bug fixes / features)
- [ ] Docs have been added or updated (for bug fixes / features) — N/A (internal bridge behaviour)
- [x] Changes target the \`main\` branch
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/)

## Additional information

Diff: +72 / -32 across one production file (`ObservableBridgeExtensions.cs`) and one test file (`BridgeTests.cs`).

Workaround PRs #157 (15m suite timeout) and #162 (60s per-test cap) stay in place as defence-in-depth — they will catch the next unidentified flake before it stalls a 15m CI run.