### PR TITLE
test: expand operator coverage and fix flaky Merge test

### DIFF
--- a/src/tests/ReactiveUI.Extensions.Tests/Async/CombiningOperatorTests.Merge.cs
+++ b/src/tests/ReactiveUI.Extensions.Tests/Async/CombiningOperatorTests.Merge.cs
@@ -576,6 +576,11 @@ public partial class CombiningOperatorTests
     }
 
     /// <summary>Tests Merge with max concurrency and error propagation.</summary>
+    /// <remarks>Background jobs run with <c>startSynchronously: true</c> so the test does
+    /// not depend on free thread-pool threads — under heavy cross-assembly parallel test runs
+    /// the default <c>Task.Yield()</c> path used to starve and the test hit the 60s timeout.
+    /// The concurrency-limit contract being asserted (four sources flow through a Merge(2)
+    /// gate and all emit) is preserved.</remarks>
     /// <returns>A <see cref="Task"/> representing the asynchronous test operation.</returns>
     [Test]
     public async Task WhenMergeConcurrencyWithSlowSource_ThenLimitsAndCompletes()
@@ -586,7 +591,8 @@ public partial class CombiningOperatorTests
                 {
                     await obs.OnNextAsync(i, ct);
                     await obs.OnCompletedAsync(Result.Success);
-                }));
+                },
+                startSynchronously: true));
 
         var result = await source.Merge(2).ToListAsync();
 

--- a/src/tests/ReactiveUI.Extensions.Tests/CurrentValueSubjectTests.MultiObserver.cs
+++ b/src/tests/ReactiveUI.Extensions.Tests/CurrentValueSubjectTests.MultiObserver.cs
@@ -1,0 +1,188 @@
+// Copyright (c) 2019-2026 ReactiveUI Association Incorporated. All rights reserved.
+// ReactiveUI Association Incorporated licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+using ReactiveUI.Extensions.Internal;
+
+namespace ReactiveUI.Extensions.Tests;
+
+/// <summary>Multi-observer and post-terminal coverage for <see cref="CurrentValueSubject{T}"/>
+/// — copy-on-write growth, mid-array unsubscribe, collapse back to single-observer, late
+/// subscribers after error or completion, and dispose with active observers.</summary>
+public partial class CurrentValueSubjectTests
+{
+    /// <summary>Initial value for multi-observer tests.</summary>
+    private const int MultiInitialValue = 1;
+
+    /// <summary>Verifies that three concurrent observers all receive the latest value.</summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous test operation.</returns>
+    [Test]
+    public async Task WhenThreeObserversAndOnNext_ThenAllReceiveValue()
+    {
+        const int Update = 2;
+        using var subject = new CurrentValueSubject<int>(MultiInitialValue);
+        var a = new List<int>();
+        var b = new List<int>();
+        var c = new List<int>();
+
+        using var subA = subject.Subscribe(a.Add);
+        using var subB = subject.Subscribe(b.Add);
+        using var subC = subject.Subscribe(c.Add);
+
+        subject.OnNext(Update);
+
+        await Assert.That(a).IsCollectionEqualTo([MultiInitialValue, Update]);
+        await Assert.That(b).IsCollectionEqualTo([MultiInitialValue, Update]);
+        await Assert.That(c).IsCollectionEqualTo([MultiInitialValue, Update]);
+    }
+
+    /// <summary>Verifies that disposing the middle observer of a 3-observer subject does not
+    /// affect the other observers' delivery.</summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous test operation.</returns>
+    [Test]
+    public async Task WhenMiddleObserverDisposed_ThenOthersStillReceive()
+    {
+        const int Update = 2;
+        using var subject = new CurrentValueSubject<int>(MultiInitialValue);
+        var a = new List<int>();
+        var b = new List<int>();
+        var c = new List<int>();
+
+        using var subA = subject.Subscribe(a.Add);
+        var subB = subject.Subscribe(b.Add);
+        using var subC = subject.Subscribe(c.Add);
+
+        subB.Dispose();
+        subject.OnNext(Update);
+
+        await Assert.That(a).IsCollectionEqualTo([MultiInitialValue, Update]);
+        await Assert.That(b).IsCollectionEqualTo([MultiInitialValue]);
+        await Assert.That(c).IsCollectionEqualTo([MultiInitialValue, Update]);
+    }
+
+    /// <summary>Verifies that going from two observers back to one collapses to the
+    /// single-observer fast path while still broadcasting correctly.</summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous test operation.</returns>
+    [Test]
+    public async Task WhenSecondObserverDisposedFromPair_ThenSingleObserverStillReceives()
+    {
+        const int Update = 2;
+        using var subject = new CurrentValueSubject<int>(MultiInitialValue);
+        var a = new List<int>();
+        var b = new List<int>();
+
+        using var subA = subject.Subscribe(a.Add);
+        var subB = subject.Subscribe(b.Add);
+        subB.Dispose();
+
+        subject.OnNext(Update);
+
+        await Assert.That(a).IsCollectionEqualTo([MultiInitialValue, Update]);
+        await Assert.That(b).IsCollectionEqualTo([MultiInitialValue]);
+    }
+
+    /// <summary>Verifies that disposing the first observer of a 3-observer subject works
+    /// (collapse exercises the index==0 branch of the shrink path).</summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous test operation.</returns>
+    [Test]
+    public async Task WhenFirstObserverDisposed_ThenOthersStillReceive()
+    {
+        const int Update = 2;
+        using var subject = new CurrentValueSubject<int>(MultiInitialValue);
+        var a = new List<int>();
+        var b = new List<int>();
+        var c = new List<int>();
+
+        var subA = subject.Subscribe(a.Add);
+        using var subB = subject.Subscribe(b.Add);
+        using var subC = subject.Subscribe(c.Add);
+
+        subA.Dispose();
+        subject.OnNext(Update);
+
+        await Assert.That(a).IsCollectionEqualTo([MultiInitialValue]);
+        await Assert.That(b).IsCollectionEqualTo([MultiInitialValue, Update]);
+        await Assert.That(c).IsCollectionEqualTo([MultiInitialValue, Update]);
+    }
+
+    /// <summary>Verifies that disposing the last observer of a 3-observer subject works
+    /// (collapse exercises the tail-only branch of the shrink path).</summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous test operation.</returns>
+    [Test]
+    public async Task WhenLastObserverDisposed_ThenOthersStillReceive()
+    {
+        const int Update = 2;
+        using var subject = new CurrentValueSubject<int>(MultiInitialValue);
+        var a = new List<int>();
+        var b = new List<int>();
+        var c = new List<int>();
+
+        using var subA = subject.Subscribe(a.Add);
+        using var subB = subject.Subscribe(b.Add);
+        var subC = subject.Subscribe(c.Add);
+
+        subC.Dispose();
+        subject.OnNext(Update);
+
+        await Assert.That(a).IsCollectionEqualTo([MultiInitialValue, Update]);
+        await Assert.That(b).IsCollectionEqualTo([MultiInitialValue, Update]);
+        await Assert.That(c).IsCollectionEqualTo([MultiInitialValue]);
+    }
+
+    /// <summary>Verifies that subscribing after the subject has errored immediately delivers the error.</summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous test operation.</returns>
+    [Test]
+    public async Task WhenSubscribeAfterError_ThenErrorDeliveredImmediately()
+    {
+        using var subject = new CurrentValueSubject<int>(MultiInitialValue);
+        var expected = new InvalidOperationException("late-error");
+        subject.OnError(expected);
+
+        Exception? caught = null;
+        using var sub = subject.Subscribe(static _ => { }, ex => caught = ex);
+
+        await Assert.That(caught).IsSameReferenceAs(expected);
+    }
+
+    /// <summary>Verifies that subscribing after the subject has completed delivers the cached
+    /// value and an immediate completion.</summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous test operation.</returns>
+    [Test]
+    public async Task WhenSubscribeAfterCompleted_ThenReplayThenCompletes()
+    {
+        using var subject = new CurrentValueSubject<int>(MultiInitialValue);
+        subject.OnCompleted();
+
+        var values = new List<int>();
+        var completed = false;
+        using var sub = subject.Subscribe(values.Add, () => completed = true);
+
+        await Assert.That(values).IsCollectionEqualTo([MultiInitialValue]);
+        await Assert.That(completed).IsTrue();
+    }
+
+    /// <summary>Verifies that <c>OnError</c> broadcasts to multiple observers and is idempotent.</summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous test operation.</returns>
+    [Test]
+    public async Task WhenMultipleObserversAndOnError_ThenAllReceiveError()
+    {
+        using var subject = new CurrentValueSubject<int>(MultiInitialValue);
+        Exception? errA = null;
+        Exception? errB = null;
+        Exception? errC = null;
+        var expected = new InvalidOperationException("multi-error");
+
+        using var subA = subject.Subscribe(static _ => { }, ex => errA = ex);
+        using var subB = subject.Subscribe(static _ => { }, ex => errB = ex);
+        using var subC = subject.Subscribe(static _ => { }, ex => errC = ex);
+
+        subject.OnError(expected);
+
+        // Second OnError is a no-op.
+        subject.OnError(new InvalidOperationException("ignored"));
+
+        await Assert.That(errA).IsSameReferenceAs(expected);
+        await Assert.That(errB).IsSameReferenceAs(expected);
+        await Assert.That(errC).IsSameReferenceAs(expected);
+    }
+}

--- a/src/tests/ReactiveUI.Extensions.Tests/CurrentValueSubjectTests.cs
+++ b/src/tests/ReactiveUI.Extensions.Tests/CurrentValueSubjectTests.cs
@@ -9,7 +9,7 @@ namespace ReactiveUI.Extensions.Tests;
 
 /// <summary>Tests for <see cref="CurrentValueSubject{T}"/>, <see cref="SingleValueObservable{T}"/>,
 /// and the <see cref="CachedObservables"/> singletons.</summary>
-public class CurrentValueSubjectTests
+public partial class CurrentValueSubjectTests
 {
     /// <summary>Initial value used by subject tests so the replay value is unambiguous.</summary>
     private const int InitialValue = 42;

--- a/src/tests/ReactiveUI.Extensions.Tests/Internal/DisposableBagTests.cs
+++ b/src/tests/ReactiveUI.Extensions.Tests/Internal/DisposableBagTests.cs
@@ -1,0 +1,118 @@
+// Copyright (c) 2019-2026 ReactiveUI Association Incorporated. All rights reserved.
+// ReactiveUI Association Incorporated licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+using ReactiveUI.Extensions.Internal.Disposables;
+
+namespace ReactiveUI.Extensions.Tests.Internal;
+
+/// <summary>Coverage for <see cref="DisposableBag"/> — inline-slot fill, overflow growth,
+/// add-after-dispose immediate disposal, three-arg constructor, and dispose-order guarantees.</summary>
+public class DisposableBagTests
+{
+    /// <summary>Verifies that the parameterless constructor accepts inline slot fills and disposes both.</summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous test operation.</returns>
+    [Test]
+    public async Task WhenDefaultBagFilledViaAdd_ThenDisposesBoth()
+    {
+        var bag = new DisposableBag();
+        var d1 = new CountedDisposable();
+        var d2 = new CountedDisposable();
+
+        bag.Add(d1);
+        bag.Add(d2);
+        bag.Dispose();
+
+        await Assert.That(d1.DisposeCount).IsEqualTo(1);
+        await Assert.That(d2.DisposeCount).IsEqualTo(1);
+    }
+
+    /// <summary>Verifies that adding a null disposable is a no-op.</summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous test operation.</returns>
+    [Test]
+    public async Task WhenAddNull_ThenIgnored()
+    {
+        var bag = new DisposableBag();
+        bag.Add(null!);
+        bag.Dispose();
+
+        await Assert.That(bag).IsNotNull();
+    }
+
+    /// <summary>Verifies that overflow growth and disposal works for more than three entries.</summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous test operation.</returns>
+    [Test]
+    public async Task WhenOverflowGrowthRequired_ThenAllEntriesDisposed()
+    {
+        const int Count = 8;
+        var bag = new DisposableBag();
+        var entries = new CountedDisposable[Count];
+        for (var i = 0; i < Count; i++)
+        {
+            entries[i] = new CountedDisposable();
+            bag.Add(entries[i]);
+        }
+
+        bag.Dispose();
+
+        for (var i = 0; i < Count; i++)
+        {
+            await Assert.That(entries[i].DisposeCount).IsEqualTo(1);
+        }
+    }
+
+    /// <summary>Verifies that the three-arg constructor populates inline slots plus overflow and disposes all.</summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous test operation.</returns>
+    [Test]
+    public async Task WhenThreeArgConstructor_ThenAllThreeDisposed()
+    {
+        var d1 = new CountedDisposable();
+        var d2 = new CountedDisposable();
+        var d3 = new CountedDisposable();
+        var bag = new DisposableBag(d1, d2, d3);
+
+        bag.Dispose();
+
+        await Assert.That(d1.DisposeCount).IsEqualTo(1);
+        await Assert.That(d2.DisposeCount).IsEqualTo(1);
+        await Assert.That(d3.DisposeCount).IsEqualTo(1);
+    }
+
+    /// <summary>Verifies that double-dispose is idempotent.</summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous test operation.</returns>
+    [Test]
+    public async Task WhenDisposeCalledTwice_ThenIdempotent()
+    {
+        var d1 = new CountedDisposable();
+        var bag = new DisposableBag(d1, new CountedDisposable());
+
+        bag.Dispose();
+        bag.Dispose();
+
+        await Assert.That(d1.DisposeCount).IsEqualTo(1);
+    }
+
+    /// <summary>Verifies that adding after disposal disposes the supplied entry immediately.</summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous test operation.</returns>
+    [Test]
+    public async Task WhenAddAfterDispose_ThenSuppliedDisposableDisposedImmediately()
+    {
+        var bag = new DisposableBag();
+        bag.Dispose();
+
+        var late = new CountedDisposable();
+        bag.Add(late);
+
+        await Assert.That(late.DisposeCount).IsEqualTo(1);
+    }
+
+    /// <summary>Tracking disposable used to count dispose invocations.</summary>
+    private sealed class CountedDisposable : IDisposable
+    {
+        /// <summary>Gets the number of times <see cref="Dispose"/> has been invoked.</summary>
+        public int DisposeCount { get; private set; }
+
+        /// <inheritdoc/>
+        public void Dispose() => DisposeCount++;
+    }
+}

--- a/src/tests/ReactiveUI.Extensions.Tests/ObservableSubscriptionExtensionsTests.SchedulerOverloads.cs
+++ b/src/tests/ReactiveUI.Extensions.Tests/ObservableSubscriptionExtensionsTests.SchedulerOverloads.cs
@@ -1,0 +1,99 @@
+// Copyright (c) 2019-2026 ReactiveUI Association Incorporated. All rights reserved.
+// ReactiveUI Association Incorporated licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+namespace ReactiveUI.Extensions.Tests;
+
+/// <summary>Coverage for the scheduler-routed overloads of the WaitFor* helpers on
+/// <see cref="ObservableSubscriptionExtensions"/>. The non-scheduler overloads are
+/// already covered in the companion file; these dispatch the subscribe call via a
+/// scheduler before blocking.</summary>
+public partial class ObservableSubscriptionExtensionsTests
+{
+    /// <summary>Sentinel value emitted by single-value scheduler tests.</summary>
+    private const int SchedulerSentinelValue = 13;
+
+    /// <summary>Default test timeout for the scheduler-routed overloads.</summary>
+    private static readonly TimeSpan SchedulerWaitTimeout = TimeSpan.FromSeconds(5);
+
+    /// <summary>Verifies that <c>WaitForValue</c> with a scheduler returns the emitted value.</summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous test operation.</returns>
+    [Test]
+    public async Task WhenWaitForValueWithSchedulerOnly_ThenReturnsEmittedValue()
+    {
+        var result = Observable.Return(SchedulerSentinelValue)
+            .WaitForValue(TaskPoolScheduler.Default);
+
+        await Assert.That(result).IsEqualTo(SchedulerSentinelValue);
+    }
+
+    /// <summary>Verifies that <c>WaitForValue</c> with a scheduler and explicit timeout returns the emitted value.</summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous test operation.</returns>
+    [Test]
+    public async Task WhenWaitForValueWithSchedulerAndTimeout_ThenReturnsEmittedValue()
+    {
+        var result = Observable.Return(SchedulerSentinelValue)
+            .WaitForValue(TaskPoolScheduler.Default, SchedulerWaitTimeout);
+
+        await Assert.That(result).IsEqualTo(SchedulerSentinelValue);
+    }
+
+    /// <summary>Verifies that the scheduler+timeout form of <c>WaitForValue</c> times out for a never-terminating source.</summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous test operation.</returns>
+    [Test]
+    public async Task WhenWaitForValueWithSchedulerTimesOut_ThenTimeoutException()
+    {
+        Action call = () => Observable.Never<int>()
+            .WaitForValue(TaskPoolScheduler.Default, TimeSpan.FromMilliseconds(50));
+        var ex = Assert.Throws<TimeoutException>(call);
+        await Assert.That(ex).IsNotNull();
+    }
+
+    /// <summary>Verifies that <c>WaitForCompletion</c> with a scheduler returns after terminal.</summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous test operation.</returns>
+    [Test]
+    public async Task WhenWaitForCompletionWithSchedulerOnly_ThenReturnsAfterTerminal()
+    {
+        Observable.Return(Unit.Default)
+            .WaitForCompletion(TaskPoolScheduler.Default);
+
+        // Sentinel follow-up to give TUnit a real assertion.
+        var sentinel = Observable.Return(SchedulerSentinelValue).SubscribeGetValue();
+        await Assert.That(sentinel).IsEqualTo(SchedulerSentinelValue);
+    }
+
+    /// <summary>Verifies that <c>WaitForCompletion</c> with a scheduler and explicit timeout returns after terminal.</summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous test operation.</returns>
+    [Test]
+    public async Task WhenWaitForCompletionWithSchedulerAndTimeout_ThenReturnsAfterTerminal()
+    {
+        Observable.Return(Unit.Default)
+            .WaitForCompletion(TaskPoolScheduler.Default, SchedulerWaitTimeout);
+
+        var sentinel = Observable.Return(SchedulerSentinelValue).SubscribeGetValue();
+        await Assert.That(sentinel).IsEqualTo(SchedulerSentinelValue);
+    }
+
+    /// <summary>Verifies that <c>WaitForError</c> with a scheduler returns null for a normal completion.</summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous test operation.</returns>
+    [Test]
+    public async Task WhenWaitForErrorWithSchedulerOnly_ThenReturnsNullOnNormalCompletion()
+    {
+        var error = Observable.Return(SchedulerSentinelValue)
+            .WaitForError(TaskPoolScheduler.Default);
+
+        await Assert.That(error).IsNull();
+    }
+
+    /// <summary>Verifies that <c>WaitForError</c> with a scheduler and timeout captures the error.</summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous test operation.</returns>
+    [Test]
+    public async Task WhenWaitForErrorWithSchedulerAndTimeout_ThenCapturesError()
+    {
+        var expected = new InvalidOperationException("scheduler-captured");
+        var error = Observable.Throw<int>(expected)
+            .WaitForError(TaskPoolScheduler.Default, SchedulerWaitTimeout);
+
+        await Assert.That(error).IsEqualTo(expected);
+    }
+}

--- a/src/tests/ReactiveUI.Extensions.Tests/ObservableSubscriptionExtensionsTests.cs
+++ b/src/tests/ReactiveUI.Extensions.Tests/ObservableSubscriptionExtensionsTests.cs
@@ -5,7 +5,7 @@
 namespace ReactiveUI.Extensions.Tests;
 
 /// <summary>Tests for the blocking subscribe helpers on <see cref="ObservableSubscriptionExtensions"/>.</summary>
-public class ObservableSubscriptionExtensionsTests
+public partial class ObservableSubscriptionExtensionsTests
 {
     /// <summary>Sentinel value emitted by single-value tests.</summary>
     private const int SentinelValue = 7;

--- a/src/tests/ReactiveUI.Extensions.Tests/Operators/BooleanReduceObservableTests.cs
+++ b/src/tests/ReactiveUI.Extensions.Tests/Operators/BooleanReduceObservableTests.cs
@@ -1,0 +1,108 @@
+// Copyright (c) 2019-2026 ReactiveUI Association Incorporated. All rights reserved.
+// ReactiveUI Association Incorporated licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+namespace ReactiveUI.Extensions.Tests.Operators;
+
+/// <summary>Edge-case coverage for the boolean-reduce operators backed by
+/// <c>BooleanReduceObservable</c> — empty-source short-circuit, partial-value
+/// suppression, target match/mismatch, error broadcast.</summary>
+public class BooleanReduceObservableTests
+{
+    /// <summary>Synthetic error message attached to source errors.</summary>
+    private const string SourceErrorMessage = "source error";
+
+    /// <summary>Verifies that an empty input emits a single <c>true</c> and completes.</summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous test operation.</returns>
+    [Test]
+    public async Task WhenCombineLatestValuesAreAllTrueWithEmptySources_ThenEmitsTrueAndCompletes()
+    {
+        var results = new List<bool>();
+        var completed = false;
+
+        using var sub = Array.Empty<IObservable<bool>>()
+            .CombineLatestValuesAreAllTrue()
+            .Subscribe(results.Add, () => completed = true);
+
+        await Assert.That(results).IsCollectionEqualTo([true]);
+        await Assert.That(completed).IsTrue();
+    }
+
+    /// <summary>Verifies that partial sources do not emit until every source has a value.</summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous test operation.</returns>
+    [Test]
+    public async Task WhenAllTruePartialSources_ThenSuppressesEmission()
+    {
+        var a = new Subject<bool>();
+        var b = new Subject<bool>();
+        var results = new List<bool>();
+
+        using var sub = new IObservable<bool>[] { a, b }
+            .CombineLatestValuesAreAllTrue()
+            .Subscribe(results.Add);
+
+        a.OnNext(true);
+
+        await Assert.That(results).IsEmpty();
+    }
+
+    /// <summary>Verifies that the operator emits <c>true</c> only when every latest value is <c>true</c>.</summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous test operation.</returns>
+    [Test]
+    public async Task WhenAllTrueTransitions_ThenEmitsExpectedSequence()
+    {
+        var a = new Subject<bool>();
+        var b = new Subject<bool>();
+        var results = new List<bool>();
+
+        using var sub = new IObservable<bool>[] { a, b }
+            .CombineLatestValuesAreAllTrue()
+            .Subscribe(results.Add);
+
+        a.OnNext(true);
+        b.OnNext(false);
+        b.OnNext(true);
+        a.OnNext(false);
+
+        await Assert.That(results).IsCollectionEqualTo([false, true, false]);
+    }
+
+    /// <summary>Verifies that <c>AllFalse</c> emits <c>true</c> only when every latest value is <c>false</c>.</summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous test operation.</returns>
+    [Test]
+    public async Task WhenAllFalseTransitions_ThenEmitsExpectedSequence()
+    {
+        var a = new Subject<bool>();
+        var b = new Subject<bool>();
+        var results = new List<bool>();
+
+        using var sub = new IObservable<bool>[] { a, b }
+            .CombineLatestValuesAreAllFalse()
+            .Subscribe(results.Add);
+
+        a.OnNext(false);
+        b.OnNext(false);
+        b.OnNext(true);
+
+        await Assert.That(results).IsCollectionEqualTo([true, false]);
+    }
+
+    /// <summary>Verifies that a source error propagates downstream.</summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous test operation.</returns>
+    [Test]
+    public async Task WhenAllTrueSourceErrors_ThenForwardsError()
+    {
+        var a = new Subject<bool>();
+        var b = new Subject<bool>();
+        Exception? caught = null;
+        var expected = new InvalidOperationException(SourceErrorMessage);
+
+        using var sub = new IObservable<bool>[] { a, b }
+            .CombineLatestValuesAreAllTrue()
+            .Subscribe(static _ => { }, ex => caught = ex);
+
+        a.OnError(expected);
+
+        await Assert.That(caught).IsSameReferenceAs(expected);
+    }
+}

--- a/src/tests/ReactiveUI.Extensions.Tests/Operators/CatchAndReturnWithFactoryObservableTests.cs
+++ b/src/tests/ReactiveUI.Extensions.Tests/Operators/CatchAndReturnWithFactoryObservableTests.cs
@@ -1,0 +1,104 @@
+// Copyright (c) 2019-2026 ReactiveUI Association Incorporated. All rights reserved.
+// ReactiveUI Association Incorporated licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+namespace ReactiveUI.Extensions.Tests.Operators;
+
+/// <summary>Edge-case coverage for the factory overload of <c>CatchAndReturn</c>
+/// backed by <c>CatchAndReturnWithFactoryObservable&lt;T, TException&gt;</c> —
+/// matching exception path, non-matching exception passthrough, and
+/// factory-error propagation.</summary>
+public class CatchAndReturnWithFactoryObservableTests
+{
+    /// <summary>Synthetic error message attached to source errors.</summary>
+    private const string SourceErrorMessage = "matching";
+
+    /// <summary>Synthetic error message attached to mismatched source errors.</summary>
+    private const string MismatchedErrorMessage = "different type";
+
+    /// <summary>Synthetic error message attached to factory failures.</summary>
+    private const string FactoryFailedMessage = "factory failed";
+
+    /// <summary>Length used to build a fallback from the captured exception message.</summary>
+    private const int FallbackBaseValue = 100;
+
+    /// <summary>Verifies that a matching exception emits a fallback from the factory and completes.</summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous test operation.</returns>
+    [Test]
+    public async Task WhenCatchAndReturnMatchingException_ThenEmitsFactoryFallbackAndCompletes()
+    {
+        var subject = new Subject<int>();
+        var results = new List<int>();
+        var completed = false;
+        var expected = new InvalidOperationException(SourceErrorMessage);
+
+        using var sub = subject.CatchAndReturn<int, InvalidOperationException>(
+                ex => FallbackBaseValue + ex.Message.Length)
+            .Subscribe(results.Add, () => completed = true);
+
+        subject.OnError(expected);
+
+        await Assert.That(results).IsCollectionEqualTo([FallbackBaseValue + SourceErrorMessage.Length]);
+        await Assert.That(completed).IsTrue();
+    }
+
+    /// <summary>Verifies that a non-matching exception passes through to <c>OnError</c>.</summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous test operation.</returns>
+    [Test]
+    public async Task WhenCatchAndReturnNonMatchingException_ThenForwardsError()
+    {
+        var subject = new Subject<int>();
+        Exception? caught = null;
+        var expected = new ArgumentException(MismatchedErrorMessage);
+
+        using var sub = subject.CatchAndReturn<int, InvalidOperationException>(
+                static _ => FallbackBaseValue)
+            .Subscribe(static _ => { }, ex => caught = ex);
+
+        subject.OnError(expected);
+
+        await Assert.That(caught).IsSameReferenceAs(expected);
+    }
+
+    /// <summary>Verifies that an exception thrown by the fallback factory replaces the original error.</summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous test operation.</returns>
+    [Test]
+    public async Task WhenCatchAndReturnFactoryThrows_ThenForwardsFactoryError()
+    {
+        var subject = new Subject<int>();
+        Exception? caught = null;
+        var sourceError = new InvalidOperationException(SourceErrorMessage);
+        var factoryError = new InvalidOperationException(FactoryFailedMessage);
+
+        using var sub = subject.CatchAndReturn<int, InvalidOperationException>(
+                _ => throw factoryError)
+            .Subscribe(static _ => { }, ex => caught = ex);
+
+        subject.OnError(sourceError);
+
+        await Assert.That(caught).IsSameReferenceAs(factoryError);
+    }
+
+    /// <summary>Verifies that <c>OnNext</c> values pass through unchanged when no error occurs.</summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous test operation.</returns>
+    [Test]
+    public async Task WhenCatchAndReturnNoError_ThenPassesValuesThrough()
+    {
+        const int First = 1;
+        const int Second = 2;
+        var subject = new Subject<int>();
+        var results = new List<int>();
+        var completed = false;
+
+        using var sub = subject.CatchAndReturn<int, InvalidOperationException>(
+                static _ => FallbackBaseValue)
+            .Subscribe(results.Add, () => completed = true);
+
+        subject.OnNext(First);
+        subject.OnNext(Second);
+        subject.OnCompleted();
+
+        await Assert.That(results).IsCollectionEqualTo([First, Second]);
+        await Assert.That(completed).IsTrue();
+    }
+}

--- a/src/tests/ReactiveUI.Extensions.Tests/Operators/ConflateObservableTests.cs
+++ b/src/tests/ReactiveUI.Extensions.Tests/Operators/ConflateObservableTests.cs
@@ -1,0 +1,118 @@
+// Copyright (c) 2019-2026 ReactiveUI Association Incorporated. All rights reserved.
+// ReactiveUI Association Incorporated licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+using Microsoft.Reactive.Testing;
+
+namespace ReactiveUI.Extensions.Tests.Operators;
+
+/// <summary>Edge-case coverage for the <c>Conflate</c> operator backed by
+/// <c>ConflateObservable&lt;T&gt;</c> — source-error path through the scheduler
+/// marshaller, completion-while-throttled, fast-path interruption by a newer value,
+/// and dispose mid-drain.</summary>
+public class ConflateObservableTests
+{
+    /// <summary>Synthetic error message attached to source errors.</summary>
+    private const string SourceErrorMessage = "source error";
+
+    /// <summary>Minimum-update-period tick window for the conflate operator.</summary>
+    private const int UpdatePeriodTicks = 100;
+
+    /// <summary>Half of the update-period window.</summary>
+    private const int HalfWindowTicks = 50;
+
+    /// <summary>Sentinel values.</summary>
+    private const int First = 1;
+
+    /// <summary>Second sentinel value.</summary>
+    private const int Second = 2;
+
+    /// <summary>Third sentinel value.</summary>
+    private const int Third = 3;
+
+    /// <summary>Verifies that a source error is forwarded through the scheduler marshaller.</summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous test operation.</returns>
+    [Test]
+    public async Task WhenConflateSourceErrors_ThenForwardsError()
+    {
+        var scheduler = new TestScheduler();
+        var subject = new Subject<int>();
+        Exception? caught = null;
+        var expected = new InvalidOperationException(SourceErrorMessage);
+
+        using var sub = subject.Conflate(TimeSpan.FromTicks(UpdatePeriodTicks), scheduler)
+            .Subscribe(static _ => { }, ex => caught = ex);
+
+        subject.OnError(expected);
+        scheduler.AdvanceBy(UpdatePeriodTicks);
+
+        await Assert.That(caught).IsSameReferenceAs(expected);
+    }
+
+    /// <summary>Verifies that a newer value arriving inside the throttle window replaces the
+    /// pending scheduled emission rather than emitting both.</summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous test operation.</returns>
+    [Test]
+    public async Task WhenConflateNewerValueDuringThrottle_ThenReplacesPending()
+    {
+        var scheduler = new TestScheduler();
+        var subject = new Subject<int>();
+        var results = new List<int>();
+
+        using var sub = subject.Conflate(TimeSpan.FromTicks(UpdatePeriodTicks), scheduler)
+            .Subscribe(results.Add);
+
+        subject.OnNext(First);
+        scheduler.AdvanceBy(HalfWindowTicks);
+        subject.OnNext(Second);
+        scheduler.AdvanceBy(HalfWindowTicks);
+        subject.OnNext(Third);
+        scheduler.AdvanceBy(UpdatePeriodTicks);
+
+        // Inside the throttle window: at most one emission for the burst.
+        await Assert.That(results.Count).IsGreaterThanOrEqualTo(1);
+        await Assert.That(results[^1]).IsEqualTo(Third);
+    }
+
+    /// <summary>Verifies that completion before any throttled emission flushes through.</summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous test operation.</returns>
+    [Test]
+    public async Task WhenConflateCompletesBeforeFirstEmission_ThenCompletes()
+    {
+        var scheduler = new TestScheduler();
+        var subject = new Subject<int>();
+        var completed = false;
+
+        using var sub = subject.Conflate(TimeSpan.FromTicks(UpdatePeriodTicks), scheduler)
+            .Subscribe(static _ => { }, () => completed = true);
+
+        subject.OnCompleted();
+        scheduler.AdvanceBy(UpdatePeriodTicks);
+
+        await Assert.That(completed).IsTrue();
+    }
+
+    /// <summary>Verifies that disposing before the scheduled emission fires suppresses the value.</summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous test operation.</returns>
+    [Test]
+    public async Task WhenConflateDisposedBeforeScheduledEmission_ThenSuppressed()
+    {
+        var scheduler = new TestScheduler();
+        var subject = new Subject<int>();
+        var results = new List<int>();
+
+        var sub = subject.Conflate(TimeSpan.FromTicks(UpdatePeriodTicks), scheduler)
+            .Subscribe(results.Add);
+
+        subject.OnNext(First);
+        scheduler.AdvanceBy(HalfWindowTicks);
+        subject.OnNext(Second);
+        sub.Dispose();
+        scheduler.AdvanceBy(UpdatePeriodTicks);
+
+        // Initial value may or may not have fired before disposal but no late emission must arrive.
+        var snapshot = results.Count;
+        scheduler.AdvanceBy(UpdatePeriodTicks);
+        await Assert.That(results.Count).IsEqualTo(snapshot);
+    }
+}

--- a/src/tests/ReactiveUI.Extensions.Tests/Operators/MinMaxObservableTests.cs
+++ b/src/tests/ReactiveUI.Extensions.Tests/Operators/MinMaxObservableTests.cs
@@ -1,0 +1,93 @@
+// Copyright (c) 2019-2026 ReactiveUI Association Incorporated. All rights reserved.
+// ReactiveUI Association Incorporated licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+namespace ReactiveUI.Extensions.Tests.Operators;
+
+/// <summary>Edge-case coverage for the <c>GetMin</c> / <c>GetMax</c> operators
+/// backed by <c>MinMaxObservable&lt;T&gt;</c> — partial-source suppression,
+/// max/min selection over multiple updates, and source-error propagation.</summary>
+public class MinMaxObservableTests
+{
+    /// <summary>Synthetic error message attached to source errors.</summary>
+    private const string SourceErrorMessage = "source error";
+
+    /// <summary>Sentinel value for the first source.</summary>
+    private const int LowValue = 1;
+
+    /// <summary>Sentinel value for the second source (initial).</summary>
+    private const int MidValue = 5;
+
+    /// <summary>Sentinel value used as an update to the second source.</summary>
+    private const int HighValue = 10;
+
+    /// <summary>Verifies that <c>GetMax</c> emits the largest of the latest values from every source.</summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous test operation.</returns>
+    [Test]
+    public async Task WhenGetMaxTwoSources_ThenEmitsMaxAcrossUpdates()
+    {
+        var a = new Subject<int>();
+        var b = new Subject<int>();
+        var results = new List<int>();
+
+        using var sub = a.GetMax(b).Subscribe(results.Add);
+
+        a.OnNext(LowValue);
+        b.OnNext(MidValue);
+        b.OnNext(HighValue);
+        a.OnNext(MidValue);
+
+        await Assert.That(results).IsCollectionEqualTo([MidValue, HighValue, HighValue]);
+    }
+
+    /// <summary>Verifies that <c>GetMin</c> emits the smallest of the latest values from every source.</summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous test operation.</returns>
+    [Test]
+    public async Task WhenGetMinTwoSources_ThenEmitsMinAcrossUpdates()
+    {
+        var a = new Subject<int>();
+        var b = new Subject<int>();
+        var results = new List<int>();
+
+        using var sub = a.GetMin(b).Subscribe(results.Add);
+
+        a.OnNext(HighValue);
+        b.OnNext(MidValue);
+        a.OnNext(LowValue);
+
+        await Assert.That(results).IsCollectionEqualTo([MidValue, LowValue]);
+    }
+
+    /// <summary>Verifies that partial sources do not emit until every source has a value.</summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous test operation.</returns>
+    [Test]
+    public async Task WhenGetMaxPartialSources_ThenSuppressesEmission()
+    {
+        var a = new Subject<int>();
+        var b = new Subject<int>();
+        var results = new List<int>();
+
+        using var sub = a.GetMax(b).Subscribe(results.Add);
+
+        a.OnNext(LowValue);
+
+        await Assert.That(results).IsEmpty();
+    }
+
+    /// <summary>Verifies that a source error propagates downstream.</summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous test operation.</returns>
+    [Test]
+    public async Task WhenGetMaxSourceErrors_ThenForwardsError()
+    {
+        var a = new Subject<int>();
+        var b = new Subject<int>();
+        Exception? caught = null;
+        var expected = new InvalidOperationException(SourceErrorMessage);
+
+        using var sub = a.GetMax(b).Subscribe(static _ => { }, ex => caught = ex);
+
+        a.OnError(expected);
+
+        await Assert.That(caught).IsSameReferenceAs(expected);
+    }
+}

--- a/src/tests/ReactiveUI.Extensions.Tests/Operators/ObserveOnIfObservableTests.cs
+++ b/src/tests/ReactiveUI.Extensions.Tests/Operators/ObserveOnIfObservableTests.cs
@@ -1,0 +1,152 @@
+// Copyright (c) 2019-2026 ReactiveUI Association Incorporated. All rights reserved.
+// ReactiveUI Association Incorporated licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+namespace ReactiveUI.Extensions.Tests.Operators;
+
+/// <summary>Edge-case coverage for the reactive-condition <c>ObserveOnIf</c> overload
+/// backed by <c>ObserveOnIfObservable&lt;T&gt;</c> — condition switching, error forwarding,
+/// and completion forwarding.</summary>
+public class ObserveOnIfObservableTests
+{
+    /// <summary>Synthetic error message attached to source errors.</summary>
+    private const string SourceErrorMessage = "source error";
+
+    /// <summary>Verifies that values dispatch on the false-scheduler before any condition arrives.</summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous test operation.</returns>
+    [Test]
+    public async Task WhenObserveOnIfNoCondition_ThenUsesFalseScheduler()
+    {
+        const int Value = 11;
+        var source = new Subject<int>();
+        var condition = new Subject<bool>();
+        var trueScheduler = new RecordingScheduler();
+        var falseScheduler = new RecordingScheduler();
+        var emitted = new TaskCompletionSource<int>(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        using var sub = source.ObserveOnIf(condition, trueScheduler, falseScheduler)
+            .Subscribe(v => emitted.TrySetResult(v));
+
+        source.OnNext(Value);
+
+        var v2 = await emitted.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        await Assert.That(v2).IsEqualTo(Value);
+        await Assert.That(falseScheduler.ScheduleCount).IsGreaterThanOrEqualTo(1);
+        await Assert.That(trueScheduler.ScheduleCount).IsEqualTo(0);
+    }
+
+    /// <summary>Verifies that emitting after the condition becomes true dispatches on the true-scheduler.</summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous test operation.</returns>
+    [Test]
+    public async Task WhenObserveOnIfConditionTrue_ThenUsesTrueScheduler()
+    {
+        const int Value = 22;
+        var source = new Subject<int>();
+        var condition = new Subject<bool>();
+        var trueScheduler = new RecordingScheduler();
+        var falseScheduler = new RecordingScheduler();
+        var emitted = new TaskCompletionSource<int>(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        using var sub = source.ObserveOnIf(condition, trueScheduler, falseScheduler)
+            .Subscribe(v => emitted.TrySetResult(v));
+
+        condition.OnNext(true);
+        source.OnNext(Value);
+
+        var v2 = await emitted.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        await Assert.That(v2).IsEqualTo(Value);
+        await Assert.That(trueScheduler.ScheduleCount).IsGreaterThanOrEqualTo(1);
+    }
+
+    /// <summary>Verifies that <c>ObserveOnIf</c> forwards source errors without scheduler dispatch.</summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous test operation.</returns>
+    [Test]
+    public async Task WhenObserveOnIfSourceErrors_ThenForwardsError()
+    {
+        var source = new Subject<int>();
+        var condition = new Subject<bool>();
+        Exception? caught = null;
+        var expected = new InvalidOperationException(SourceErrorMessage);
+
+        using var sub = source.ObserveOnIf(condition, TaskPoolScheduler.Default, ImmediateScheduler.Instance)
+            .Subscribe(static _ => { }, ex => caught = ex);
+
+        source.OnError(expected);
+
+        await Assert.That(caught).IsSameReferenceAs(expected);
+    }
+
+    /// <summary>Verifies that <c>ObserveOnIf</c> forwards source completion.</summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous test operation.</returns>
+    [Test]
+    public async Task WhenObserveOnIfSourceCompletes_ThenForwardsCompletion()
+    {
+        var source = new Subject<int>();
+        var condition = new Subject<bool>();
+        var completed = false;
+
+        using var sub = source.ObserveOnIf(condition, TaskPoolScheduler.Default, ImmediateScheduler.Instance)
+            .Subscribe(static _ => { }, () => completed = true);
+
+        source.OnCompleted();
+
+        await Assert.That(completed).IsTrue();
+    }
+
+    /// <summary>Verifies that the single-scheduler overload defaults the false branch to
+    /// <see cref="ImmediateScheduler"/> by emitting synchronously when the condition is false.</summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous test operation.</returns>
+    [Test]
+    public async Task WhenObserveOnIfSingleSchedulerConditionFalse_ThenImmediate()
+    {
+        const int Value = 33;
+        var source = new Subject<int>();
+        var condition = new Subject<bool>();
+        var trueScheduler = new RecordingScheduler();
+        var results = new List<int>();
+
+        using var sub = source.ObserveOnIf(condition, trueScheduler)
+            .Subscribe(results.Add);
+
+        condition.OnNext(false);
+        source.OnNext(Value);
+
+        await Assert.That(results).IsCollectionEqualTo([Value]);
+        await Assert.That(trueScheduler.ScheduleCount).IsEqualTo(0);
+    }
+
+    /// <summary>Scheduler that delegates to the default thread-pool scheduler but records
+    /// each call to <see cref="IScheduler.Schedule{TState}(TState, Func{IScheduler, TState, IDisposable})"/>.</summary>
+    private sealed class RecordingScheduler : IScheduler
+    {
+        /// <summary>Backing scheduler used to actually dispatch work.</summary>
+        private readonly TaskPoolScheduler _inner = TaskPoolScheduler.Default;
+
+        /// <summary>Gets the number of recorded schedule calls.</summary>
+        public int ScheduleCount { get; private set; }
+
+        /// <inheritdoc/>
+        public DateTimeOffset Now => _inner.Now;
+
+        /// <inheritdoc/>
+        public IDisposable Schedule<TState>(TState state, Func<IScheduler, TState, IDisposable> action)
+        {
+            ScheduleCount++;
+            return _inner.Schedule(state, action);
+        }
+
+        /// <inheritdoc/>
+        public IDisposable Schedule<TState>(TState state, TimeSpan dueTime, Func<IScheduler, TState, IDisposable> action)
+        {
+            ScheduleCount++;
+            return _inner.Schedule(state, dueTime, action);
+        }
+
+        /// <inheritdoc/>
+        public IDisposable Schedule<TState>(TState state, DateTimeOffset dueTime, Func<IScheduler, TState, IDisposable> action)
+        {
+            ScheduleCount++;
+            return _inner.Schedule(state, dueTime, action);
+        }
+    }
+}

--- a/src/tests/ReactiveUI.Extensions.Tests/Operators/PartitionObservableTests.cs
+++ b/src/tests/ReactiveUI.Extensions.Tests/Operators/PartitionObservableTests.cs
@@ -1,0 +1,147 @@
+// Copyright (c) 2019-2026 ReactiveUI Association Incorporated. All rights reserved.
+// ReactiveUI Association Incorporated licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+namespace ReactiveUI.Extensions.Tests.Operators;
+
+/// <summary>Edge-case coverage for <c>Partition</c> backed by
+/// <c>PartitionObservable&lt;T&gt;</c> — both-sides routing, single-side disposal,
+/// error broadcast, completion broadcast, and re-subscription after both sides drop.</summary>
+public class PartitionObservableTests
+{
+    /// <summary>Synthetic error message attached to source errors.</summary>
+    private const string SourceErrorMessage = "source error";
+
+    /// <summary>Even-modulus divisor.</summary>
+    private const int Two = 2;
+
+    /// <summary>First odd value.</summary>
+    private const int One = 1;
+
+    /// <summary>Second odd value.</summary>
+    private const int Three = 3;
+
+    /// <summary>Second even value.</summary>
+    private const int Four = 4;
+
+    /// <summary>Verifies that elements route to the correct side based on the predicate.</summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous test operation.</returns>
+    [Test]
+    public async Task WhenPartitionWithBothSidesSubscribed_ThenRoutesByPredicate()
+    {
+        var subject = new Subject<int>();
+        var (evens, odds) = subject.Partition(static x => x % Two == 0);
+        var evenResults = new List<int>();
+        var oddResults = new List<int>();
+
+        using var evenSub = evens.Subscribe(evenResults.Add);
+        using var oddSub = odds.Subscribe(oddResults.Add);
+
+        subject.OnNext(One);
+        subject.OnNext(Two);
+        subject.OnNext(Three);
+        subject.OnNext(Four);
+
+        await Assert.That(evenResults).IsCollectionEqualTo([Two, Four]);
+        await Assert.That(oddResults).IsCollectionEqualTo([One, Three]);
+    }
+
+    /// <summary>Verifies that a value with no observer on its side is silently dropped.</summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous test operation.</returns>
+    [Test]
+    public async Task WhenPartitionOnlyOneSideSubscribed_ThenOtherSideValuesDropped()
+    {
+        var subject = new Subject<int>();
+        var (evens, _) = subject.Partition(static x => x % Two == 0);
+        var evenResults = new List<int>();
+
+        using var evenSub = evens.Subscribe(evenResults.Add);
+
+        subject.OnNext(One);
+        subject.OnNext(Two);
+
+        await Assert.That(evenResults).IsCollectionEqualTo([Two]);
+    }
+
+    /// <summary>Verifies that errors are broadcast to both sides.</summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous test operation.</returns>
+    [Test]
+    public async Task WhenPartitionSourceErrors_ThenBroadcastsToBothSides()
+    {
+        var subject = new Subject<int>();
+        var (evens, odds) = subject.Partition(static x => x % Two == 0);
+        Exception? evenError = null;
+        Exception? oddError = null;
+        var expected = new InvalidOperationException(SourceErrorMessage);
+
+        using var evenSub = evens.Subscribe(static _ => { }, ex => evenError = ex);
+        using var oddSub = odds.Subscribe(static _ => { }, ex => oddError = ex);
+
+        subject.OnError(expected);
+
+        await Assert.That(evenError).IsSameReferenceAs(expected);
+        await Assert.That(oddError).IsSameReferenceAs(expected);
+    }
+
+    /// <summary>Verifies that completion is broadcast to both sides.</summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous test operation.</returns>
+    [Test]
+    public async Task WhenPartitionSourceCompletes_ThenBroadcastsToBothSides()
+    {
+        var subject = new Subject<int>();
+        var (evens, odds) = subject.Partition(static x => x % Two == 0);
+        var evenCompleted = false;
+        var oddCompleted = false;
+
+        using var evenSub = evens.Subscribe(static _ => { }, () => evenCompleted = true);
+        using var oddSub = odds.Subscribe(static _ => { }, () => oddCompleted = true);
+
+        subject.OnCompleted();
+
+        await Assert.That(evenCompleted).IsTrue();
+        await Assert.That(oddCompleted).IsTrue();
+    }
+
+    /// <summary>Verifies that disposing one side stops it from receiving further emissions
+    /// while the other side keeps receiving.</summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous test operation.</returns>
+    [Test]
+    public async Task WhenPartitionOneSideDisposed_ThenOnlyOtherSideReceives()
+    {
+        var subject = new Subject<int>();
+        var (evens, odds) = subject.Partition(static x => x % Two == 0);
+        var evenResults = new List<int>();
+        var oddResults = new List<int>();
+
+        var evenSub = evens.Subscribe(evenResults.Add);
+        using var oddSub = odds.Subscribe(oddResults.Add);
+
+        subject.OnNext(Two);
+        evenSub.Dispose();
+        subject.OnNext(Four);
+        subject.OnNext(Three);
+
+        await Assert.That(evenResults).IsCollectionEqualTo([Two]);
+        await Assert.That(oddResults).IsCollectionEqualTo([Three]);
+    }
+
+    /// <summary>Verifies that the partition can be resubscribed after all sides drop —
+    /// the source subscription is re-established.</summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous test operation.</returns>
+    [Test]
+    public async Task WhenPartitionResubscribedAfterAllSidesDropped_ThenSourceRebound()
+    {
+        var subject = new Subject<int>();
+        var (evens, _) = subject.Partition(static x => x % Two == 0);
+
+        var firstSub = evens.Subscribe(static _ => { });
+        firstSub.Dispose();
+
+        var secondResults = new List<int>();
+        using var secondSub = evens.Subscribe(secondResults.Add);
+
+        subject.OnNext(Two);
+
+        await Assert.That(secondResults).IsCollectionEqualTo([Two]);
+    }
+}

--- a/src/tests/ReactiveUI.Extensions.Tests/Operators/PropertyChangedObservableTests.cs
+++ b/src/tests/ReactiveUI.Extensions.Tests/Operators/PropertyChangedObservableTests.cs
@@ -1,0 +1,160 @@
+// Copyright (c) 2019-2026 ReactiveUI Association Incorporated. All rights reserved.
+// ReactiveUI Association Incorporated licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+namespace ReactiveUI.Extensions.Tests.Operators;
+
+/// <summary>Edge-case coverage for <c>ToPropertyObservable</c> backed by
+/// <c>PropertyChangedObservable&lt;T, TProperty&gt;</c> — initial-value emission,
+/// matching-name forwarding, unmatched-name filtering, getter-throws forwarding,
+/// and dispose detaches the handler.</summary>
+public class PropertyChangedObservableTests
+{
+    /// <summary>Initial property value.</summary>
+    private const int InitialValue = 1;
+
+    /// <summary>Updated property value.</summary>
+    private const int UpdatedValue = 42;
+
+    /// <summary>Synthetic error message attached to getter failures.</summary>
+    private const string GetterFailedMessage = "getter failed";
+
+    /// <summary>Verifies that subscribing emits the current property value immediately.</summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous test operation.</returns>
+    [Test]
+    public async Task WhenSubscribePropertyObservable_ThenEmitsCurrentValue()
+    {
+        var owner = new ObservableOwner { Value = InitialValue };
+        var results = new List<int>();
+
+        using var sub = owner.ToPropertyObservable(x => x.Value)
+            .Subscribe(results.Add);
+
+        await Assert.That(results).IsCollectionEqualTo([InitialValue]);
+    }
+
+    /// <summary>Verifies that matching-name property changes are forwarded.</summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous test operation.</returns>
+    [Test]
+    public async Task WhenMatchingPropertyChanges_ThenForwardsValue()
+    {
+        var owner = new ObservableOwner { Value = InitialValue };
+        var results = new List<int>();
+
+        using var sub = owner.ToPropertyObservable(x => x.Value)
+            .Subscribe(results.Add);
+
+        owner.Value = UpdatedValue;
+
+        await Assert.That(results).IsCollectionEqualTo([InitialValue, UpdatedValue]);
+    }
+
+    /// <summary>Verifies that non-matching property changes are ignored.</summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous test operation.</returns>
+    [Test]
+    public async Task WhenUnrelatedPropertyChanges_ThenIgnored()
+    {
+        var owner = new ObservableOwner { Value = InitialValue };
+        var results = new List<int>();
+
+        using var sub = owner.ToPropertyObservable(x => x.Value)
+            .Subscribe(results.Add);
+
+        owner.Other = "anything";
+
+        await Assert.That(results).IsCollectionEqualTo([InitialValue]);
+    }
+
+    /// <summary>Verifies that disposing detaches the handler and stops forwarding.</summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous test operation.</returns>
+    [Test]
+    public async Task WhenSubscriptionDisposed_ThenNoFurtherEmissions()
+    {
+        var owner = new ObservableOwner { Value = InitialValue };
+        var results = new List<int>();
+
+        var sub = owner.ToPropertyObservable(x => x.Value)
+            .Subscribe(results.Add);
+        sub.Dispose();
+
+        owner.Value = UpdatedValue;
+
+        await Assert.That(results).IsCollectionEqualTo([InitialValue]);
+    }
+
+    /// <summary>Verifies that an exception thrown by the getter on a property-changed callback
+    /// is forwarded to <c>OnError</c>. The initial subscribe read succeeds; the second read (triggered
+    /// by <c>Raise</c>) throws.</summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous test operation.</returns>
+    [Test]
+    public async Task WhenGetterThrowsOnChange_ThenForwardsError()
+    {
+        var owner = new LatchingThrowingOwner();
+        Exception? caught = null;
+
+        using var sub = owner.ToPropertyObservable(x => x.Latched)
+            .Subscribe(static _ => { }, ex => caught = ex);
+
+        owner.ArmAndRaise();
+
+        await Assert.That(caught).IsTypeOf<InvalidOperationException>();
+    }
+
+    /// <summary>Test owner that fires <see cref="INotifyPropertyChanged"/> on property writes.</summary>
+    private sealed class ObservableOwner : INotifyPropertyChanged
+    {
+        /// <summary>Backing field for <see cref="Value"/>.</summary>
+        private int _value;
+
+        /// <summary>Backing field for <see cref="Other"/>.</summary>
+        private string _other = string.Empty;
+
+        /// <inheritdoc/>
+        public event PropertyChangedEventHandler? PropertyChanged;
+
+        /// <summary>Gets or sets the value being observed by the test.</summary>
+        public int Value
+        {
+            get => _value;
+            set
+            {
+                _value = value;
+                PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(Value)));
+            }
+        }
+
+        /// <summary>Gets or sets the unrelated property used to validate name-filtering.</summary>
+        public string Other
+        {
+            get => _other;
+            set
+            {
+                _other = value;
+                PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(Other)));
+            }
+        }
+    }
+
+    /// <summary>Test owner whose getter succeeds on the first read but throws on subsequent reads.</summary>
+    private sealed class LatchingThrowingOwner : INotifyPropertyChanged
+    {
+        /// <summary>Failure message used by the latched getter.</summary>
+        private readonly string _message = GetterFailedMessage;
+
+        /// <summary>Set after <see cref="ArmAndRaise"/> latches the getter into throwing mode.</summary>
+        private bool _armed;
+
+        /// <inheritdoc/>
+        public event PropertyChangedEventHandler? PropertyChanged;
+
+        /// <summary>Gets a property that succeeds while disarmed and throws once armed.</summary>
+        public int Latched => _armed ? throw new InvalidOperationException(_message) : 0;
+
+        /// <summary>Arms the throwing behaviour and raises a change notification.</summary>
+        public void ArmAndRaise()
+        {
+            _armed = true;
+            PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(Latched)));
+        }
+    }
+}

--- a/src/tests/ReactiveUI.Extensions.Tests/Operators/RunAllObservableTests.cs
+++ b/src/tests/ReactiveUI.Extensions.Tests/Operators/RunAllObservableTests.cs
@@ -1,0 +1,137 @@
+// Copyright (c) 2019-2026 ReactiveUI Association Incorporated. All rights reserved.
+// ReactiveUI Association Incorporated licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+namespace ReactiveUI.Extensions.Tests.Operators;
+
+/// <summary>Edge-case coverage for <c>RunAll</c> backed by <c>RunAllObservable</c> —
+/// empty-list short-circuit, sequential walk through synchronous and asynchronous
+/// sources, error propagation, and disposal mid-walk.</summary>
+public class RunAllObservableTests
+{
+    /// <summary>Synthetic error message attached to source errors.</summary>
+    private const string SourceErrorMessage = "source error";
+
+    /// <summary>Verifies that an empty list emits <see cref="Unit"/> and completes immediately.</summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous test operation.</returns>
+    [Test]
+    public async Task WhenRunAllEmptyList_ThenEmitsAndCompletes()
+    {
+        var emitted = 0;
+        var completed = false;
+
+        using var sub = Array.Empty<IObservable<Unit>>().RunAll()
+            .Subscribe(_ => emitted++, () => completed = true);
+
+        await Assert.That(emitted).IsEqualTo(1);
+        await Assert.That(completed).IsTrue();
+    }
+
+    /// <summary>Verifies that synchronous sources iterate without stack growth and complete.</summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous test operation.</returns>
+    [Test]
+    public async Task WhenRunAllSyncSources_ThenWalksAllAndCompletes()
+    {
+        const int SourceCount = 5;
+        var runOrder = new List<int>();
+        var sources = new IObservable<Unit>[SourceCount];
+        for (var i = 0; i < SourceCount; i++)
+        {
+            var index = i;
+            sources[i] = Observable.Defer(() =>
+            {
+                runOrder.Add(index);
+                return Observable.Return(Unit.Default);
+            });
+        }
+
+        var emitted = 0;
+        var completed = false;
+
+        using var sub = ((IReadOnlyList<IObservable<Unit>>)sources).RunAll()
+            .Subscribe(_ => emitted++, () => completed = true);
+
+        await Assert.That(runOrder).IsCollectionEqualTo(BuildIndexSequence(SourceCount));
+        await Assert.That(emitted).IsEqualTo(1);
+        await Assert.That(completed).IsTrue();
+    }
+
+    /// <summary>Verifies that asynchronous sources complete in order before emitting.</summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous test operation.</returns>
+    [Test]
+    public async Task WhenRunAllAsyncSources_ThenWalksSequentially()
+    {
+        var subjectA = new Subject<Unit>();
+        var subjectB = new Subject<Unit>();
+        IObservable<Unit>[] sources = [subjectA, subjectB];
+        var completed = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        using var sub = ((IReadOnlyList<IObservable<Unit>>)sources).RunAll()
+            .Subscribe(static _ => { }, () => completed.TrySetResult(true));
+
+        await Assert.That(subjectA.HasObservers).IsTrue();
+        await Assert.That(subjectB.HasObservers).IsFalse();
+
+        subjectA.OnCompleted();
+
+        await Assert.That(subjectB.HasObservers).IsTrue();
+        subjectB.OnCompleted();
+
+        var done = await completed.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        await Assert.That(done).IsTrue();
+    }
+
+    /// <summary>Verifies that an error in any source propagates and aborts the walk.</summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous test operation.</returns>
+    [Test]
+    public async Task WhenRunAllSourceErrors_ThenForwardsAndStops()
+    {
+        var subjectA = new Subject<Unit>();
+        var subjectB = new Subject<Unit>();
+        IObservable<Unit>[] sources = [subjectA, subjectB];
+        Exception? caught = null;
+        var expected = new InvalidOperationException(SourceErrorMessage);
+
+        using var sub = ((IReadOnlyList<IObservable<Unit>>)sources).RunAll()
+            .Subscribe(static _ => { }, ex => caught = ex);
+
+        subjectA.OnError(expected);
+
+        await Assert.That(caught).IsSameReferenceAs(expected);
+        await Assert.That(subjectB.HasObservers).IsFalse();
+    }
+
+    /// <summary>Verifies that disposing mid-walk releases the active subscription.</summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous test operation.</returns>
+    [Test]
+    public async Task WhenRunAllDisposedMidWalk_ThenStops()
+    {
+        var subjectA = new Subject<Unit>();
+        var subjectB = new Subject<Unit>();
+        IObservable<Unit>[] sources = [subjectA, subjectB];
+        var completed = false;
+
+        var sub = ((IReadOnlyList<IObservable<Unit>>)sources).RunAll()
+            .Subscribe(static _ => { }, () => completed = true);
+
+        sub.Dispose();
+        subjectA.OnCompleted();
+
+        await Assert.That(completed).IsFalse();
+        await Assert.That(subjectB.HasObservers).IsFalse();
+    }
+
+    /// <summary>Returns <c>[0, 1, …, count-1]</c> for collection-equality assertions.</summary>
+    /// <param name="count">The exclusive upper bound.</param>
+    /// <returns>A new array of zero-based indices.</returns>
+    private static int[] BuildIndexSequence(int count)
+    {
+        var output = new int[count];
+        for (var i = 0; i < count; i++)
+        {
+            output[i] = i;
+        }
+
+        return output;
+    }
+}

--- a/src/tests/ReactiveUI.Extensions.Tests/Operators/SampleLatestObservableTests.cs
+++ b/src/tests/ReactiveUI.Extensions.Tests/Operators/SampleLatestObservableTests.cs
@@ -1,0 +1,135 @@
+// Copyright (c) 2019-2026 ReactiveUI Association Incorporated. All rights reserved.
+// ReactiveUI Association Incorporated licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+namespace ReactiveUI.Extensions.Tests.Operators;
+
+/// <summary>Edge-case coverage for <c>SampleLatest</c> backed by
+/// <c>SampleLatestObservable&lt;T&gt;</c> — trigger before any source value,
+/// source completion, source error, trigger error, and trigger completion not
+/// terminating downstream.</summary>
+public class SampleLatestObservableTests
+{
+    /// <summary>Synthetic error message attached to source errors.</summary>
+    private const string SourceErrorMessage = "source error";
+
+    /// <summary>Synthetic error message attached to trigger errors.</summary>
+    private const string TriggerErrorMessage = "trigger error";
+
+    /// <summary>Trigger token reused across tests.</summary>
+    private static readonly object TriggerToken = new();
+
+    /// <summary>Verifies that a trigger arriving before any source value does not emit.</summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous test operation.</returns>
+    [Test]
+    public async Task WhenSampleLatestTriggerBeforeAnyValue_ThenNoEmission()
+    {
+        var source = new Subject<int>();
+        var trigger = new Subject<object>();
+        var results = new List<int>();
+
+        using var sub = source.SampleLatest(trigger)
+            .Subscribe(results.Add);
+
+        trigger.OnNext(TriggerToken);
+
+        await Assert.That(results).IsEmpty();
+    }
+
+    /// <summary>Verifies that <c>SampleLatest</c> emits the latest source value on each trigger.</summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous test operation.</returns>
+    [Test]
+    public async Task WhenSampleLatestTriggerAfterValues_ThenEmitsLatest()
+    {
+        const int First = 1;
+        const int Second = 2;
+        var source = new Subject<int>();
+        var trigger = new Subject<object>();
+        var results = new List<int>();
+
+        using var sub = source.SampleLatest(trigger)
+            .Subscribe(results.Add);
+
+        source.OnNext(First);
+        source.OnNext(Second);
+        trigger.OnNext(TriggerToken);
+        trigger.OnNext(TriggerToken);
+
+        await Assert.That(results).IsCollectionEqualTo([Second, Second]);
+    }
+
+    /// <summary>Verifies that <c>SampleLatest</c> forwards source errors.</summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous test operation.</returns>
+    [Test]
+    public async Task WhenSampleLatestSourceErrors_ThenForwardsError()
+    {
+        var source = new Subject<int>();
+        var trigger = new Subject<object>();
+        Exception? caught = null;
+        var expected = new InvalidOperationException(SourceErrorMessage);
+
+        using var sub = source.SampleLatest(trigger)
+            .Subscribe(static _ => { }, ex => caught = ex);
+
+        source.OnError(expected);
+
+        await Assert.That(caught).IsSameReferenceAs(expected);
+    }
+
+    /// <summary>Verifies that <c>SampleLatest</c> forwards trigger errors.</summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous test operation.</returns>
+    [Test]
+    public async Task WhenSampleLatestTriggerErrors_ThenForwardsError()
+    {
+        var source = new Subject<int>();
+        var trigger = new Subject<object>();
+        Exception? caught = null;
+        var expected = new InvalidOperationException(TriggerErrorMessage);
+
+        using var sub = source.SampleLatest(trigger)
+            .Subscribe(static _ => { }, ex => caught = ex);
+
+        trigger.OnError(expected);
+
+        await Assert.That(caught).IsSameReferenceAs(expected);
+    }
+
+    /// <summary>Verifies that source completion is forwarded downstream.</summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous test operation.</returns>
+    [Test]
+    public async Task WhenSampleLatestSourceCompletes_ThenForwardsCompletion()
+    {
+        var source = new Subject<int>();
+        var trigger = new Subject<object>();
+        var completed = false;
+
+        using var sub = source.SampleLatest(trigger)
+            .Subscribe(static _ => { }, () => completed = true);
+
+        source.OnCompleted();
+
+        await Assert.That(completed).IsTrue();
+    }
+
+    /// <summary>Verifies that trigger completion alone does NOT complete the downstream sequence.</summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous test operation.</returns>
+    [Test]
+    public async Task WhenSampleLatestTriggerCompletes_ThenDownstreamRemainsOpen()
+    {
+        const int Value = 7;
+        var source = new Subject<int>();
+        var trigger = new Subject<object>();
+        var results = new List<int>();
+        var completed = false;
+
+        using var sub = source.SampleLatest(trigger)
+            .Subscribe(results.Add, () => completed = true);
+
+        source.OnNext(Value);
+        trigger.OnCompleted();
+
+        // After trigger completion, source values are still tracked. No emission, no termination.
+        await Assert.That(completed).IsFalse();
+        await Assert.That(results).IsEmpty();
+    }
+}

--- a/src/tests/ReactiveUI.Extensions.Tests/Operators/ScanWithInitialTests.Terminal.cs
+++ b/src/tests/ReactiveUI.Extensions.Tests/Operators/ScanWithInitialTests.Terminal.cs
@@ -1,0 +1,86 @@
+// Copyright (c) 2019-2026 ReactiveUI Association Incorporated. All rights reserved.
+// ReactiveUI Association Incorporated licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+namespace ReactiveUI.Extensions.Tests.Operators;
+
+/// <summary>Terminal-notification coverage for <c>ScanWithInitial</c> — source error,
+/// source completion, and post-terminal value ignore.</summary>
+public partial class ScanWithInitialTests
+{
+    /// <summary>Synthetic error message attached to source errors.</summary>
+    private const string SourceErrorMessage = "source error";
+
+    /// <summary>Initial accumulator value.</summary>
+    private const int TerminalInitial = 0;
+
+    /// <summary>Verifies that <c>OnError</c> is forwarded after the initial value has been emitted.</summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous test operation.</returns>
+    [Test]
+    public async Task WhenScanSourceErrors_ThenForwardsError()
+    {
+        var subject = new Subject<int>();
+        Exception? caught = null;
+        var expected = new InvalidOperationException(SourceErrorMessage);
+
+        using var sub = subject.ScanWithInitial(TerminalInitial, static (acc, x) => acc + x)
+            .Subscribe(static _ => { }, ex => caught = ex);
+
+        subject.OnError(expected);
+
+        await Assert.That(caught).IsSameReferenceAs(expected);
+    }
+
+    /// <summary>Verifies that <c>OnCompleted</c> is forwarded.</summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous test operation.</returns>
+    [Test]
+    public async Task WhenScanSourceCompletes_ThenForwardsCompletion()
+    {
+        var subject = new Subject<int>();
+        var completed = false;
+
+        using var sub = subject.ScanWithInitial(TerminalInitial, static (acc, x) => acc + x)
+            .Subscribe(static _ => { }, () => completed = true);
+
+        subject.OnCompleted();
+
+        await Assert.That(completed).IsTrue();
+    }
+
+    /// <summary>Verifies that values arriving after <c>OnError</c> are ignored.</summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous test operation.</returns>
+    [Test]
+    public async Task WhenScanValueAfterError_ThenIgnored()
+    {
+        const int IgnoredValue = 5;
+        var subject = new Subject<int>();
+        var results = new List<int>();
+        var expected = new InvalidOperationException(SourceErrorMessage);
+
+        using var sub = subject.ScanWithInitial(TerminalInitial, static (acc, x) => acc + x)
+            .Subscribe(results.Add, static _ => { });
+
+        subject.OnError(expected);
+        subject.OnNext(IgnoredValue);
+
+        await Assert.That(results).IsCollectionEqualTo([TerminalInitial]);
+    }
+
+    /// <summary>Verifies that values arriving after <c>OnCompleted</c> are ignored.</summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous test operation.</returns>
+    [Test]
+    public async Task WhenScanValueAfterCompleted_ThenIgnored()
+    {
+        const int IgnoredValue = 5;
+        var subject = new Subject<int>();
+        var results = new List<int>();
+
+        using var sub = subject.ScanWithInitial(TerminalInitial, static (acc, x) => acc + x)
+            .Subscribe(results.Add);
+
+        subject.OnCompleted();
+        subject.OnNext(IgnoredValue);
+
+        await Assert.That(results).IsCollectionEqualTo([TerminalInitial]);
+    }
+}

--- a/src/tests/ReactiveUI.Extensions.Tests/Operators/ScanWithInitialTests.cs
+++ b/src/tests/ReactiveUI.Extensions.Tests/Operators/ScanWithInitialTests.cs
@@ -7,7 +7,7 @@ namespace ReactiveUI.Extensions.Tests.Operators;
 /// <summary>
 /// Tests for the <see cref="ScanWithInitialObservable{TSource, TAccumulate}"/> class.
 /// </summary>
-public class ScanWithInitialTests
+public partial class ScanWithInitialTests
 {
 #if NET9_0_OR_GREATER
     /// <summary>Synchronization gate used by tests.</summary>

--- a/src/tests/ReactiveUI.Extensions.Tests/Operators/SelectAsyncConcurrentObservableTests.cs
+++ b/src/tests/ReactiveUI.Extensions.Tests/Operators/SelectAsyncConcurrentObservableTests.cs
@@ -1,0 +1,140 @@
+// Copyright (c) 2019-2026 ReactiveUI Association Incorporated. All rights reserved.
+// ReactiveUI Association Incorporated licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+namespace ReactiveUI.Extensions.Tests.Operators;
+
+/// <summary>Edge-case coverage for <c>SelectAsyncConcurrent</c> backed by
+/// <c>SelectAsyncConcurrentObservable&lt;TSource, TResult&gt;</c> — error forwarding,
+/// disposal mid-flight, and deferred completion while in-flight selectors finish.</summary>
+public class SelectAsyncConcurrentObservableTests
+{
+    /// <summary>Synthetic error message attached to a failing selector.</summary>
+    private const string SelectorErrorMessage = "selector failed";
+
+    /// <summary>Synthetic error message attached to source errors.</summary>
+    private const string SourceErrorMessage = "source error";
+
+    /// <summary>Settle delay in milliseconds used to let an awaited continuation attempt delivery.</summary>
+    private const int SettleDelayMilliseconds = 50;
+
+    /// <summary>Max concurrency used for two-in-flight tests.</summary>
+    private const int MaxConcurrencyTwo = 2;
+
+    /// <summary>Max concurrency used for four-in-flight tests.</summary>
+    private const int MaxConcurrencyFour = 4;
+
+    /// <summary>Verifies that <c>SelectAsyncConcurrent</c> forwards selector exceptions.</summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous test operation.</returns>
+    [Test]
+    public async Task WhenSelectAsyncConcurrentSelectorThrows_ThenForwardsError()
+    {
+        const int TriggerValue = 1;
+        var subject = new Subject<int>();
+        var faulted = new TaskCompletionSource<Exception>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var expected = new InvalidOperationException(SelectorErrorMessage);
+
+        using var sub = subject.SelectAsyncConcurrent<int, int>(
+            _ => Task.FromException<int>(expected),
+            maxConcurrency: MaxConcurrencyTwo)
+            .Subscribe(static _ => { }, ex => faulted.TrySetResult(ex));
+
+        subject.OnNext(TriggerValue);
+
+        var caught = await faulted.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        await Assert.That(caught).IsSameReferenceAs(expected);
+    }
+
+    /// <summary>Verifies that <c>SelectAsyncConcurrent</c> forwards source errors.</summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous test operation.</returns>
+    [Test]
+    public async Task WhenSelectAsyncConcurrentSourceErrors_ThenForwardsError()
+    {
+        var subject = new Subject<int>();
+        Exception? caught = null;
+        var expected = new InvalidOperationException(SourceErrorMessage);
+
+        using var sub = subject.SelectAsyncConcurrent(static x => Task.FromResult(x), maxConcurrency: MaxConcurrencyTwo)
+            .Subscribe(static _ => { }, ex => caught = ex);
+
+        subject.OnError(expected);
+
+        await Assert.That(caught).IsSameReferenceAs(expected);
+    }
+
+    /// <summary>Verifies that disposing the subscription mid-flight suppresses
+    /// further emissions and completion.</summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous test operation.</returns>
+    [Test]
+    public async Task WhenSelectAsyncConcurrentDisposedMidFlight_ThenSuppressesEmissionAndCompletion()
+    {
+        const int TriggerValue = 1;
+        var subject = new Subject<int>();
+        var gate = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var results = new List<int>();
+        var completed = false;
+
+        var sub = subject.SelectAsyncConcurrent(
+            async x =>
+            {
+                await gate.Task.ConfigureAwait(false);
+                return x;
+            },
+            maxConcurrency: MaxConcurrencyTwo)
+            .Subscribe(results.Add, () => completed = true);
+
+        subject.OnNext(TriggerValue);
+        subject.OnCompleted();
+        sub.Dispose();
+        gate.TrySetResult(true);
+
+        await Task.Delay(SettleDelayMilliseconds).ConfigureAwait(false);
+
+        await Assert.That(results).IsEmpty();
+        await Assert.That(completed).IsFalse();
+    }
+
+    /// <summary>Verifies that completion arriving while selectors are still in flight
+    /// is forwarded after all selectors finish.</summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous test operation.</returns>
+    [Test]
+    public async Task WhenSelectAsyncConcurrentCompletesWithInFlight_ThenDeferredCompletion()
+    {
+        const int First = 1;
+        const int Second = 2;
+        var subject = new Subject<int>();
+        var gate = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var results = new List<int>();
+        var completed = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        using var sub = subject.SelectAsyncConcurrent(
+            async x =>
+            {
+                await gate.Task.ConfigureAwait(false);
+                return x;
+            },
+            maxConcurrency: MaxConcurrencyFour)
+            .Subscribe(
+                results.Add,
+                () => completed.TrySetResult(true));
+
+        subject.OnNext(First);
+        subject.OnNext(Second);
+        subject.OnCompleted();
+
+        // The selector is gated; nothing should have emitted yet.
+        await Task.Delay(SettleDelayMilliseconds).ConfigureAwait(false);
+        await Assert.That(completed.Task.IsCompleted).IsFalse();
+
+        gate.TrySetResult(true);
+
+        var done = await completed.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        await Assert.That(done).IsTrue();
+
+        // Downstream OnNext from this operator is serialized inside the sink's lock, so the
+        // list is safely populated by the time completion fires. Order is concurrent so sort.
+        int[] sorted = [.. results];
+        Array.Sort(sorted);
+        await Assert.That(sorted).IsCollectionEqualTo([First, Second]);
+    }
+}

--- a/src/tests/ReactiveUI.Extensions.Tests/Operators/SelectAsyncSequentialObservableTests.cs
+++ b/src/tests/ReactiveUI.Extensions.Tests/Operators/SelectAsyncSequentialObservableTests.cs
@@ -1,0 +1,123 @@
+// Copyright (c) 2019-2026 ReactiveUI Association Incorporated. All rights reserved.
+// ReactiveUI Association Incorporated licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+namespace ReactiveUI.Extensions.Tests.Operators;
+
+/// <summary>Edge-case coverage for <c>SelectAsyncSequential</c> backed by
+/// <c>SelectAsyncSequentialObservable&lt;TSource, TResult&gt;</c> — error forwarding,
+/// disposal mid-flight, and completion while an in-flight selector is running.</summary>
+public class SelectAsyncSequentialObservableTests
+{
+    /// <summary>Synthetic error message attached to a failing selector.</summary>
+    private const string SelectorErrorMessage = "selector failed";
+
+    /// <summary>Synthetic error message attached to source errors.</summary>
+    private const string SourceErrorMessage = "source error";
+
+    /// <summary>Settle delay in milliseconds used to let an awaited continuation attempt delivery.</summary>
+    private const int SettleDelayMilliseconds = 50;
+
+    /// <summary>Verifies that <c>SelectAsyncSequential</c> forwards selector exceptions
+    /// and stops draining the queue afterwards.</summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous test operation.</returns>
+    [Test]
+    public async Task WhenSelectAsyncSequentialSelectorThrows_ThenForwardsErrorAndStops()
+    {
+        const int First = 1;
+        const int Second = 2;
+        var subject = new Subject<int>();
+        var faulted = new TaskCompletionSource<Exception>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var results = new List<int>();
+        var expected = new InvalidOperationException(SelectorErrorMessage);
+
+        using var sub = subject.SelectAsyncSequential<int, int>(x =>
+            x == First ? Task.FromException<int>(expected) : Task.FromResult(x))
+            .Subscribe(results.Add, ex => faulted.TrySetResult(ex));
+
+        subject.OnNext(First);
+        subject.OnNext(Second);
+
+        var caught = await faulted.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        await Assert.That(caught).IsSameReferenceAs(expected);
+        await Assert.That(results).IsEmpty();
+    }
+
+    /// <summary>Verifies that <c>SelectAsyncSequential</c> forwards source errors.</summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous test operation.</returns>
+    [Test]
+    public async Task WhenSelectAsyncSequentialSourceErrors_ThenForwardsError()
+    {
+        var subject = new Subject<int>();
+        Exception? caught = null;
+        var expected = new InvalidOperationException(SourceErrorMessage);
+
+        using var sub = subject.SelectAsyncSequential(static x => Task.FromResult(x))
+            .Subscribe(static _ => { }, ex => caught = ex);
+
+        subject.OnError(expected);
+
+        await Assert.That(caught).IsSameReferenceAs(expected);
+    }
+
+    /// <summary>Verifies that disposing the subscription mid-flight suppresses
+    /// further emissions and completion.</summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous test operation.</returns>
+    [Test]
+    public async Task WhenSelectAsyncSequentialDisposedMidFlight_ThenSuppressesEmissionAndCompletion()
+    {
+        const int TriggerValue = 1;
+        var subject = new Subject<int>();
+        var gate = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var results = new List<int>();
+        var completed = false;
+
+        var sub = subject.SelectAsyncSequential(async x =>
+        {
+            await gate.Task.ConfigureAwait(false);
+            return x;
+        }).Subscribe(results.Add, () => completed = true);
+
+        subject.OnNext(TriggerValue);
+        subject.OnCompleted();
+        sub.Dispose();
+        gate.TrySetResult(true);
+
+        await Task.Delay(SettleDelayMilliseconds).ConfigureAwait(false);
+
+        await Assert.That(results).IsEmpty();
+        await Assert.That(completed).IsFalse();
+    }
+
+    /// <summary>Verifies that completion arriving while a selector is in flight
+    /// is forwarded after the in-flight selector finishes.</summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous test operation.</returns>
+    [Test]
+    public async Task WhenSelectAsyncSequentialCompletesWhileProcessing_ThenDeferredCompletion()
+    {
+        const int Value = 42;
+        var subject = new Subject<int>();
+        var gate = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var results = new List<int>();
+        var completed = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        using var sub = subject.SelectAsyncSequential(async x =>
+        {
+            await gate.Task.ConfigureAwait(false);
+            return x;
+        }).Subscribe(results.Add, () => completed.TrySetResult(true));
+
+        subject.OnNext(Value);
+        subject.OnCompleted();
+
+        // Completion must not fire while selector is gated.
+        await Task.Delay(SettleDelayMilliseconds).ConfigureAwait(false);
+        await Assert.That(completed.Task.IsCompleted).IsFalse();
+
+        gate.TrySetResult(true);
+
+        var done = await completed.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        await Assert.That(done).IsTrue();
+        await Assert.That(results).IsCollectionEqualTo([Value]);
+    }
+}

--- a/src/tests/ReactiveUI.Extensions.Tests/Operators/SelectLatestAsyncObservableTests.cs
+++ b/src/tests/ReactiveUI.Extensions.Tests/Operators/SelectLatestAsyncObservableTests.cs
@@ -1,0 +1,150 @@
+// Copyright (c) 2019-2026 ReactiveUI Association Incorporated. All rights reserved.
+// ReactiveUI Association Incorporated licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+namespace ReactiveUI.Extensions.Tests.Operators;
+
+/// <summary>Edge-case coverage for <c>SelectLatestAsync</c> backed by
+/// <c>SelectLatestAsyncObservable&lt;TSource, TResult&gt;</c> — error forwarding,
+/// disposal mid-flight, stale-id drop path and completion-after-in-flight.</summary>
+public class SelectLatestAsyncObservableTests
+{
+    /// <summary>Synthetic error message attached to a failing selector.</summary>
+    private const string SelectorErrorMessage = "selector failed";
+
+    /// <summary>Synthetic error message attached to source errors.</summary>
+    private const string SourceErrorMessage = "source error";
+
+    /// <summary>Settle delay in milliseconds used to let an awaited continuation attempt delivery.</summary>
+    private const int SettleDelayMilliseconds = 50;
+
+    /// <summary>Poll interval in milliseconds used while waiting for an emission.</summary>
+    private const int PollIntervalMilliseconds = 10;
+
+    /// <summary>Multiplier applied inside the projection selector.</summary>
+    private const int ProjectionMultiplier = 10;
+
+    /// <summary>Verifies that <c>SelectLatestAsync</c> forwards selector exceptions.</summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous test operation.</returns>
+    [Test]
+    public async Task WhenSelectLatestAsyncSelectorThrows_ThenForwardsError()
+    {
+        const int TriggerValue = 1;
+        var subject = new Subject<int>();
+        var faulted = new TaskCompletionSource<Exception>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var expected = new InvalidOperationException(SelectorErrorMessage);
+
+        using var sub = subject.SelectLatestAsync<int, int>(_ => Task.FromException<int>(expected))
+            .Subscribe(static _ => { }, ex => faulted.TrySetResult(ex));
+
+        subject.OnNext(TriggerValue);
+
+        var caught = await faulted.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        await Assert.That(caught).IsSameReferenceAs(expected);
+    }
+
+    /// <summary>Verifies that <c>SelectLatestAsync</c> forwards source errors immediately.</summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous test operation.</returns>
+    [Test]
+    public async Task WhenSelectLatestAsyncSourceErrors_ThenForwardsError()
+    {
+        var subject = new Subject<int>();
+        Exception? caught = null;
+        var expected = new InvalidOperationException(SourceErrorMessage);
+
+        using var sub = subject.SelectLatestAsync(static x => Task.FromResult(x))
+            .Subscribe(static _ => { }, ex => caught = ex);
+
+        subject.OnError(expected);
+
+        await Assert.That(caught).IsSameReferenceAs(expected);
+    }
+
+    /// <summary>Verifies that disposing the subscription before the selector completes
+    /// suppresses any later <c>OnNext</c> / <c>OnCompleted</c>.</summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous test operation.</returns>
+    [Test]
+    public async Task WhenSelectLatestAsyncDisposedMidFlight_ThenSuppressesEmissionAndCompletion()
+    {
+        const int TriggerValue = 1;
+        var subject = new Subject<int>();
+        var gate = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var results = new List<int>();
+        var completed = false;
+
+        var sub = subject.SelectLatestAsync(async x =>
+        {
+            await gate.Task.ConfigureAwait(false);
+            return x * 2;
+        }).Subscribe(results.Add, () => completed = true);
+
+        subject.OnNext(TriggerValue);
+        subject.OnCompleted();
+        sub.Dispose();
+        gate.TrySetResult(true);
+
+        // Give the awaited continuation a chance to attempt delivery.
+        await Task.Delay(SettleDelayMilliseconds).ConfigureAwait(false);
+
+        await Assert.That(results).IsEmpty();
+        await Assert.That(completed).IsFalse();
+    }
+
+    /// <summary>Verifies that a newer value supersedes a slower in-flight projection,
+    /// so only the latest result is emitted.</summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous test operation.</returns>
+    [Test]
+    public async Task WhenSelectLatestAsyncNewerArrives_ThenOlderResultDropped()
+    {
+        const int Slow = 1;
+        const int Fast = 2;
+        var subject = new Subject<int>();
+        var slowGate = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var results = new List<int>();
+        var completed = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        using var sub = subject.SelectLatestAsync(async x =>
+        {
+            if (x == Slow)
+            {
+                await slowGate.Task.ConfigureAwait(false);
+            }
+
+            return x * ProjectionMultiplier;
+        }).Subscribe(results.Add, () => completed.TrySetResult(true));
+
+        subject.OnNext(Slow);
+        subject.OnNext(Fast);
+
+        // Wait for the fast projection to complete and emit.
+        while (results.Count == 0)
+        {
+            await Task.Delay(PollIntervalMilliseconds).ConfigureAwait(false);
+        }
+
+        slowGate.TrySetResult(true);
+        subject.OnCompleted();
+
+        await completed.Task.WaitAsync(TimeSpan.FromSeconds(5));
+
+        // Only the latest (Fast) projection's result should appear.
+        await Assert.That(results).IsCollectionEqualTo([Fast * ProjectionMultiplier]);
+    }
+
+    /// <summary>Verifies that source completion before any value still completes downstream.</summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous test operation.</returns>
+    [Test]
+    public async Task WhenSelectLatestAsyncSourceCompletesWithNoValues_ThenForwardsCompletion()
+    {
+        var subject = new Subject<int>();
+        var completed = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        using var sub = subject.SelectLatestAsync(static x => Task.FromResult(x))
+            .Subscribe(static _ => { }, () => completed.TrySetResult(true));
+
+        subject.OnCompleted();
+
+        var done = await completed.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        await Assert.That(done).IsTrue();
+    }
+}

--- a/src/tests/ReactiveUI.Extensions.Tests/Operators/SelectManyThenObservableTests.cs
+++ b/src/tests/ReactiveUI.Extensions.Tests/Operators/SelectManyThenObservableTests.cs
@@ -1,0 +1,145 @@
+// Copyright (c) 2019-2026 ReactiveUI Association Incorporated. All rights reserved.
+// ReactiveUI Association Incorporated licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+namespace ReactiveUI.Extensions.Tests.Operators;
+
+/// <summary>Edge-case coverage for <c>SelectManyThen</c> backed by
+/// <c>SelectManyThenObservable&lt;TSource, TMid, TResult&gt;</c> — two-stage projection,
+/// first/second projection throws, source error/completion, and inner-observable errors.</summary>
+public class SelectManyThenObservableTests
+{
+    /// <summary>Synthetic error messages.</summary>
+    private const string SourceErrorMessage = "source error";
+
+    /// <summary>Synthetic error for the first projection.</summary>
+    private const string FirstProjectionFailedMessage = "first failed";
+
+    /// <summary>Synthetic error for the second projection.</summary>
+    private const string SecondProjectionFailedMessage = "second failed";
+
+    /// <summary>Synthetic error for the inner observable.</summary>
+    private const string InnerErrorMessage = "inner error";
+
+    /// <summary>Multiplier used to derive intermediate values from the source.</summary>
+    private const int IntermediateMultiplier = 10;
+
+    /// <summary>Multiplier used to derive final values from the intermediate.</summary>
+    private const int FinalMultiplier = 7;
+
+    /// <summary>Source sentinel value.</summary>
+    private const int SourceValue = 3;
+
+    /// <summary>Verifies that values flow through both projections to downstream.</summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous test operation.</returns>
+    [Test]
+    public async Task WhenSelectManyThenTwoStages_ThenComposesProjections()
+    {
+        var results = new List<int>();
+
+        using var sub = Observable.Return(SourceValue)
+            .SelectManyThen(
+                static x => Observable.Return(x * IntermediateMultiplier),
+                static mid => Observable.Return(mid * FinalMultiplier))
+            .Subscribe(results.Add);
+
+        await Assert.That(results).IsCollectionEqualTo([SourceValue * IntermediateMultiplier * FinalMultiplier]);
+    }
+
+    /// <summary>Verifies that a throwing first projection forwards the error.</summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous test operation.</returns>
+    [Test]
+    public async Task WhenSelectManyThenFirstThrows_ThenForwardsError()
+    {
+        Exception? caught = null;
+        var expected = new InvalidOperationException(FirstProjectionFailedMessage);
+
+        using var sub = Observable.Return(SourceValue)
+            .SelectManyThen<int, int, int>(
+                _ => throw expected,
+                static _ => Observable.Return(0))
+            .Subscribe(static _ => { }, ex => caught = ex);
+
+        await Assert.That(caught).IsSameReferenceAs(expected);
+    }
+
+    /// <summary>Verifies that a throwing second projection forwards the error.</summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous test operation.</returns>
+    [Test]
+    public async Task WhenSelectManyThenSecondThrows_ThenForwardsError()
+    {
+        Exception? caught = null;
+        var expected = new InvalidOperationException(SecondProjectionFailedMessage);
+
+        using var sub = Observable.Return(SourceValue)
+            .SelectManyThen<int, int, int>(
+                static x => Observable.Return(x),
+                _ => throw expected)
+            .Subscribe(static _ => { }, ex => caught = ex);
+
+        await Assert.That(caught).IsSameReferenceAs(expected);
+    }
+
+    /// <summary>Verifies that a source error is forwarded.</summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous test operation.</returns>
+    [Test]
+    public async Task WhenSelectManyThenSourceErrors_ThenForwardsError()
+    {
+        var subject = new Subject<int>();
+        Exception? caught = null;
+        var expected = new InvalidOperationException(SourceErrorMessage);
+
+        using var sub = subject.SelectManyThen(
+                static x => Observable.Return(x),
+                static x => Observable.Return(x))
+            .Subscribe(static _ => { }, ex => caught = ex);
+
+        subject.OnError(expected);
+
+        await Assert.That(caught).IsSameReferenceAs(expected);
+    }
+
+    /// <summary>Verifies that a source completion is forwarded.</summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous test operation.</returns>
+    [Test]
+    public async Task WhenSelectManyThenSourceCompletes_ThenForwardsCompletion()
+    {
+        var subject = new Subject<int>();
+        var completed = false;
+
+        using var sub = subject.SelectManyThen(
+                static x => Observable.Return(x),
+                static x => Observable.Return(x))
+            .Subscribe(static _ => { }, () => completed = true);
+
+        subject.OnCompleted();
+
+        await Assert.That(completed).IsTrue();
+    }
+
+    /// <summary>Verifies that an inner-observable error is forwarded.</summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous test operation.</returns>
+    [Test]
+    public async Task WhenSelectManyThenInnerErrors_ThenForwardsError()
+    {
+        Exception? caught = null;
+        var expected = new InvalidOperationException(InnerErrorMessage);
+
+        using var sub = Observable.Return(SourceValue)
+            .SelectManyThen(
+                static _ => Observable.Throw<int>(new InvalidOperationException("first-inner")),
+                static x => Observable.Return(x))
+            .Subscribe(static _ => { }, ex => caught = ex);
+
+        await Assert.That(caught).IsNotNull();
+
+        Exception? caughtSecond = null;
+        using var sub2 = Observable.Return(SourceValue)
+            .SelectManyThen(
+                static x => Observable.Return(x),
+                _ => Observable.Throw<int>(expected))
+            .Subscribe(static _ => { }, ex => caughtSecond = ex);
+
+        await Assert.That(caughtSecond).IsSameReferenceAs(expected);
+    }
+}

--- a/src/tests/ReactiveUI.Extensions.Tests/Operators/StartActionObservableTests.cs
+++ b/src/tests/ReactiveUI.Extensions.Tests/Operators/StartActionObservableTests.cs
@@ -1,0 +1,75 @@
+// Copyright (c) 2019-2026 ReactiveUI Association Incorporated. All rights reserved.
+// ReactiveUI Association Incorporated licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+namespace ReactiveUI.Extensions.Tests.Operators;
+
+/// <summary>Edge-case coverage for the action-form <c>Start</c> operator backed by
+/// <c>StartActionObservable</c> — synchronous inline path, scheduler dispatch,
+/// and action-throws forwarding.</summary>
+public class StartActionObservableTests
+{
+    /// <summary>Synthetic error message attached to action failures.</summary>
+    private const string ActionFailedMessage = "action failed";
+
+    /// <summary>Verifies that <c>Start</c> with a null scheduler runs synchronously and completes.</summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous test operation.</returns>
+    [Test]
+    public async Task WhenStartActionInline_ThenRunsAndCompletes()
+    {
+        var ran = false;
+        var completed = false;
+        var emitted = 0;
+
+        using var sub = ReactiveExtensions.Start(() => ran = true, scheduler: null)
+            .Subscribe(_ => emitted++, () => completed = true);
+
+        await Assert.That(ran).IsTrue();
+        await Assert.That(emitted).IsEqualTo(1);
+        await Assert.That(completed).IsTrue();
+    }
+
+    /// <summary>Verifies that <c>Start</c> with a scheduler dispatches the action via that scheduler.</summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous test operation.</returns>
+    [Test]
+    public async Task WhenStartActionWithScheduler_ThenRunsViaScheduler()
+    {
+        var completed = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var ran = false;
+
+        using var sub = ReactiveExtensions.Start(() => ran = true, TaskPoolScheduler.Default)
+            .Subscribe(static _ => { }, () => completed.TrySetResult(true));
+
+        await completed.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        await Assert.That(ran).IsTrue();
+    }
+
+    /// <summary>Verifies that an exception thrown by the inline action is forwarded to <c>OnError</c>.</summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous test operation.</returns>
+    [Test]
+    public async Task WhenStartActionThrowsInline_ThenForwardsError()
+    {
+        Exception? caught = null;
+        var expected = new InvalidOperationException(ActionFailedMessage);
+
+        using var sub = ReactiveExtensions.Start(() => throw expected, scheduler: null)
+            .Subscribe(static _ => { }, ex => caught = ex);
+
+        await Assert.That(caught).IsSameReferenceAs(expected);
+    }
+
+    /// <summary>Verifies that an exception thrown by the scheduled action is forwarded to <c>OnError</c>.</summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous test operation.</returns>
+    [Test]
+    public async Task WhenStartActionThrowsScheduled_ThenForwardsError()
+    {
+        var faulted = new TaskCompletionSource<Exception>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var expected = new InvalidOperationException(ActionFailedMessage);
+
+        using var sub = ReactiveExtensions.Start(() => throw expected, TaskPoolScheduler.Default)
+            .Subscribe(static _ => { }, ex => faulted.TrySetResult(ex));
+
+        var caught = await faulted.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        await Assert.That(caught).IsSameReferenceAs(expected);
+    }
+}

--- a/src/tests/ReactiveUI.Extensions.Tests/Operators/SubscribeAsyncObservableTests.cs
+++ b/src/tests/ReactiveUI.Extensions.Tests/Operators/SubscribeAsyncObservableTests.cs
@@ -1,0 +1,135 @@
+// Copyright (c) 2019-2026 ReactiveUI Association Incorporated. All rights reserved.
+// ReactiveUI Association Incorporated licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+namespace ReactiveUI.Extensions.Tests.Operators;
+
+/// <summary>Edge-case coverage for the <c>SubscribeSynchronous</c> / <c>SubscribeAsync</c>
+/// overloads backed by <c>SubscribeAsyncObservable&lt;T&gt;</c> — sequential handler invocation,
+/// handler-throws forwards via onError, completion-while-processing defers, disposal stops queue.</summary>
+public class SubscribeAsyncObservableTests
+{
+    /// <summary>Synthetic error message attached to handler failures.</summary>
+    private const string HandlerFailedMessage = "handler failed";
+
+    /// <summary>Synthetic error message attached to source errors.</summary>
+    private const string SourceErrorMessage = "source error";
+
+    /// <summary>Settle delay in milliseconds used to confirm completion is deferred.</summary>
+    private const int SettleDelayMilliseconds = 50;
+
+    /// <summary>Verifies that values are handled in order and completion fires.</summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous test operation.</returns>
+    [Test]
+    public async Task WhenSubscribeAsyncProcessesValues_ThenInOrder()
+    {
+        const int First = 1;
+        const int Second = 2;
+        var subject = new Subject<int>();
+        var results = new List<int>();
+        var completed = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        using var sub = subject.SubscribeSynchronous<int>(
+            x =>
+            {
+                results.Add(x);
+                return Task.CompletedTask;
+            },
+            static _ => { },
+            () => completed.TrySetResult(true));
+
+        subject.OnNext(First);
+        subject.OnNext(Second);
+        subject.OnCompleted();
+
+        var done = await completed.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        await Assert.That(done).IsTrue();
+        await Assert.That(results).IsCollectionEqualTo([First, Second]);
+    }
+
+    /// <summary>Verifies that a handler exception is forwarded to the error callback.</summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous test operation.</returns>
+    [Test]
+    public async Task WhenSubscribeAsyncHandlerThrows_ThenForwardsToOnError()
+    {
+        const int TriggerValue = 1;
+        var subject = new Subject<int>();
+        var faulted = new TaskCompletionSource<Exception>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var expected = new InvalidOperationException(HandlerFailedMessage);
+
+        using var sub = subject.SubscribeSynchronous<int>(
+            _ => Task.FromException(expected),
+            ex => faulted.TrySetResult(ex));
+
+        subject.OnNext(TriggerValue);
+
+        var caught = await faulted.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        await Assert.That(caught).IsSameReferenceAs(expected);
+    }
+
+    /// <summary>Verifies that source errors are forwarded to the error callback.</summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous test operation.</returns>
+    [Test]
+    public async Task WhenSubscribeAsyncSourceErrors_ThenForwardsToOnError()
+    {
+        var subject = new Subject<int>();
+        Exception? caught = null;
+        var expected = new InvalidOperationException(SourceErrorMessage);
+
+        using var sub = subject.SubscribeSynchronous<int>(
+            static _ => Task.CompletedTask,
+            ex => caught = ex);
+
+        subject.OnError(expected);
+
+        await Assert.That(caught).IsSameReferenceAs(expected);
+    }
+
+    /// <summary>Verifies that completion arriving while a handler is in flight defers
+    /// completion until the handler finishes.</summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous test operation.</returns>
+    [Test]
+    public async Task WhenSubscribeAsyncCompletesWhileProcessing_ThenDeferredCompletion()
+    {
+        const int Value = 7;
+        var subject = new Subject<int>();
+        var gate = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var completed = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        using var sub = subject.SubscribeSynchronous<int>(
+            async _ => await gate.Task.ConfigureAwait(false),
+            () => completed.TrySetResult(true));
+
+        subject.OnNext(Value);
+        subject.OnCompleted();
+
+        await Task.Delay(SettleDelayMilliseconds).ConfigureAwait(false);
+        await Assert.That(completed.Task.IsCompleted).IsFalse();
+
+        gate.TrySetResult(true);
+
+        var done = await completed.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        await Assert.That(done).IsTrue();
+    }
+
+    /// <summary>Verifies that disposing the subscription stops further handler invocations.</summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous test operation.</returns>
+    [Test]
+    public async Task WhenSubscribeAsyncDisposed_ThenStopsProcessing()
+    {
+        const int IgnoredValue = 1;
+        var subject = new Subject<int>();
+        var handlerRan = 0;
+
+        var sub = subject.SubscribeSynchronous<int>(_ =>
+        {
+            Interlocked.Increment(ref handlerRan);
+            return Task.CompletedTask;
+        });
+
+        sub.Dispose();
+        subject.OnNext(IgnoredValue);
+
+        await Assert.That(Volatile.Read(ref handlerRan)).IsEqualTo(0);
+    }
+}

--- a/src/tests/ReactiveUI.Extensions.Tests/Operators/ThrottleUntilTrueObservableTests.cs
+++ b/src/tests/ReactiveUI.Extensions.Tests/Operators/ThrottleUntilTrueObservableTests.cs
@@ -1,0 +1,138 @@
+// Copyright (c) 2019-2026 ReactiveUI Association Incorporated. All rights reserved.
+// ReactiveUI Association Incorporated licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+namespace ReactiveUI.Extensions.Tests.Operators;
+
+/// <summary>Edge-case coverage for <c>ThrottleUntilTrue</c> backed by
+/// <c>ThrottleUntilTrueObservable&lt;T&gt;</c> — predicate-true bypass, predicate-false
+/// throttling, error forwarding, completion forwarding, and dispose-before-fire.</summary>
+public class ThrottleUntilTrueObservableTests
+{
+    /// <summary>Synthetic error message attached to source errors.</summary>
+    private const string SourceErrorMessage = "source error";
+
+    /// <summary>Throttle window in milliseconds for tests.</summary>
+    private const int ThrottleWindowMilliseconds = 50;
+
+    /// <summary>Long throttle window in milliseconds used by the dispose-before-fire test.</summary>
+    private const int LongThrottleWindowMilliseconds = 500;
+
+    /// <summary>Settle delay in milliseconds used to confirm a throttled emission never fires.</summary>
+    private const int SettleDelayMilliseconds = 150;
+
+    /// <summary>Throttle window for tests.</summary>
+    private static readonly TimeSpan ThrottleWindow = TimeSpan.FromMilliseconds(ThrottleWindowMilliseconds);
+
+    /// <summary>Verifies that elements matching the predicate emit immediately.</summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous test operation.</returns>
+    [Test]
+    public async Task WhenThrottleUntilTruePredicateTrue_ThenEmitsImmediately()
+    {
+        const int MatchingValue = 1;
+        var subject = new Subject<int>();
+        var emitted = new TaskCompletionSource<int>(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        using var sub = subject.ThrottleUntilTrue(ThrottleWindow, static x => x == MatchingValue)
+            .Subscribe(v => emitted.TrySetResult(v));
+
+        subject.OnNext(MatchingValue);
+
+        var got = await emitted.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        await Assert.That(got).IsEqualTo(MatchingValue);
+    }
+
+    /// <summary>Verifies that non-matching elements are throttled but eventually emit.</summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous test operation.</returns>
+    [Test]
+    public async Task WhenThrottleUntilTruePredicateFalse_ThenEmitsAfterDelay()
+    {
+        const int NonMatchingValue = 99;
+        var subject = new Subject<int>();
+        var emitted = new TaskCompletionSource<int>(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        using var sub = subject.ThrottleUntilTrue(ThrottleWindow, static _ => false)
+            .Subscribe(v => emitted.TrySetResult(v));
+
+        subject.OnNext(NonMatchingValue);
+
+        var got = await emitted.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        await Assert.That(got).IsEqualTo(NonMatchingValue);
+    }
+
+    /// <summary>Verifies that a later throttled value replaces an earlier still-pending one.</summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous test operation.</returns>
+    [Test]
+    public async Task WhenThrottleUntilTrueFastReplacements_ThenLatestWins()
+    {
+        const int Earlier = 1;
+        const int Later = 2;
+        var subject = new Subject<int>();
+        var emitted = new TaskCompletionSource<int>(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        using var sub = subject.ThrottleUntilTrue(ThrottleWindow, static _ => false)
+            .Subscribe(v => emitted.TrySetResult(v));
+
+        subject.OnNext(Earlier);
+        subject.OnNext(Later);
+
+        var got = await emitted.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        await Assert.That(got).IsEqualTo(Later);
+    }
+
+    /// <summary>Verifies that source errors are forwarded.</summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous test operation.</returns>
+    [Test]
+    public async Task WhenThrottleUntilTrueSourceErrors_ThenForwardsError()
+    {
+        var subject = new Subject<int>();
+        Exception? caught = null;
+        var expected = new InvalidOperationException(SourceErrorMessage);
+
+        using var sub = subject.ThrottleUntilTrue(ThrottleWindow, static _ => true)
+            .Subscribe(static _ => { }, ex => caught = ex);
+
+        subject.OnError(expected);
+
+        await Assert.That(caught).IsSameReferenceAs(expected);
+    }
+
+    /// <summary>Verifies that source completion is forwarded and post-completion values ignored.</summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous test operation.</returns>
+    [Test]
+    public async Task WhenThrottleUntilTrueSourceCompletes_ThenForwardsCompletion()
+    {
+        const int IgnoredAfterCompletion = 9;
+        var subject = new Subject<int>();
+        var completed = false;
+
+        using var sub = subject.ThrottleUntilTrue(ThrottleWindow, static _ => true)
+            .Subscribe(static _ => { }, () => completed = true);
+
+        subject.OnCompleted();
+        subject.OnNext(IgnoredAfterCompletion);
+
+        await Assert.That(completed).IsTrue();
+    }
+
+    /// <summary>Verifies that disposing before a throttled emission fires suppresses it.</summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous test operation.</returns>
+    [Test]
+    public async Task WhenThrottleUntilTrueDisposedBeforeFire_ThenNoEmission()
+    {
+        const int NonMatchingValue = 1;
+        var subject = new Subject<int>();
+        var results = new List<int>();
+
+        var sub = subject.ThrottleUntilTrue(TimeSpan.FromMilliseconds(LongThrottleWindowMilliseconds), static _ => false)
+            .Subscribe(results.Add);
+
+        subject.OnNext(NonMatchingValue);
+        sub.Dispose();
+
+        // Wait past the throttle window to confirm nothing fires.
+        await Task.Delay(SettleDelayMilliseconds).ConfigureAwait(false);
+
+        await Assert.That(results).IsEmpty();
+    }
+}

--- a/src/tests/ReactiveUI.Extensions.Tests/Operators/UsingActionObservableTests.cs
+++ b/src/tests/ReactiveUI.Extensions.Tests/Operators/UsingActionObservableTests.cs
@@ -1,0 +1,109 @@
+// Copyright (c) 2019-2026 ReactiveUI Association Incorporated. All rights reserved.
+// ReactiveUI Association Incorporated licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+namespace ReactiveUI.Extensions.Tests.Operators;
+
+/// <summary>Edge-case coverage for the action-form <c>Using</c> operator backed by
+/// <c>UsingActionObservable&lt;T&gt;</c> — happy path, null action, scheduler dispatch,
+/// and action-throws-then-disposes paths.</summary>
+public class UsingActionObservableTests
+{
+    /// <summary>Synthetic error message attached to action failures.</summary>
+    private const string ActionFailedMessage = "action failed";
+
+    /// <summary>Verifies that <c>Using</c> with a null action still emits, completes,
+    /// and disposes the resource.</summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous test operation.</returns>
+    [Test]
+    public async Task WhenUsingNullAction_ThenEmitsUnitCompletesAndDisposes()
+    {
+        var resource = new TrackedDisposable();
+        var completed = false;
+        var emitted = 0;
+
+        using var sub = resource.Using(action: null)
+            .Subscribe(_ => emitted++, () => completed = true);
+
+        await Assert.That(emitted).IsEqualTo(1);
+        await Assert.That(completed).IsTrue();
+        await Assert.That(resource.DisposeCount).IsEqualTo(1);
+    }
+
+    /// <summary>Verifies that <c>Using</c> invokes the action against the resource
+    /// and disposes after completion.</summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous test operation.</returns>
+    [Test]
+    public async Task WhenUsingActionInvoked_ThenActionRunsThenResourceDisposed()
+    {
+        var resource = new TrackedDisposable();
+        var actionRan = false;
+        var completed = false;
+
+        using var sub = resource.Using(r =>
+        {
+            actionRan = true;
+            ThrowIfDisposed(r);
+        }).Subscribe(static _ => { }, () => completed = true);
+
+        await Assert.That(actionRan).IsTrue();
+        await Assert.That(completed).IsTrue();
+        await Assert.That(resource.DisposeCount).IsEqualTo(1);
+    }
+
+    /// <summary>Verifies that an action exception forwards the error and still disposes the resource.</summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous test operation.</returns>
+    [Test]
+    public async Task WhenUsingActionThrows_ThenForwardsErrorAndDisposes()
+    {
+        var resource = new TrackedDisposable();
+        Exception? caught = null;
+        var expected = new InvalidOperationException(ActionFailedMessage);
+
+        using var sub = resource.Using(_ => throw expected)
+            .Subscribe(static _ => { }, ex => caught = ex);
+
+        await Assert.That(caught).IsSameReferenceAs(expected);
+        await Assert.That(resource.DisposeCount).IsEqualTo(1);
+    }
+
+    /// <summary>Verifies that the scheduler overload dispatches via the scheduler and still
+    /// invokes the action then disposes the resource.</summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous test operation.</returns>
+    [Test]
+    public async Task WhenUsingWithScheduler_ThenRunsViaScheduler()
+    {
+        var resource = new TrackedDisposable();
+        var completed = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var actionRan = false;
+
+        using var sub = resource.Using(_ => actionRan = true, scheduler: TaskPoolScheduler.Default)
+            .Subscribe(static _ => { }, () => completed.TrySetResult(true));
+
+        await completed.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        await Assert.That(actionRan).IsTrue();
+        await Assert.That(resource.DisposeCount).IsEqualTo(1);
+    }
+
+    /// <summary>Throws when the resource was disposed before the action ran.</summary>
+    /// <param name="resource">The resource to check.</param>
+    private static void ThrowIfDisposed(TrackedDisposable resource)
+    {
+        if (resource.DisposeCount == 0)
+        {
+            return;
+        }
+
+        throw new InvalidOperationException("disposed before action ran");
+    }
+
+    /// <summary>Disposable that counts how many times it has been disposed.</summary>
+    private sealed class TrackedDisposable : IDisposable
+    {
+        /// <summary>Gets the number of times <see cref="Dispose"/> has been invoked.</summary>
+        public int DisposeCount { get; private set; }
+
+        /// <inheritdoc/>
+        public void Dispose() => DisposeCount++;
+    }
+}

--- a/src/tests/ReactiveUI.Extensions.Tests/Operators/WhileObservableTests.cs
+++ b/src/tests/ReactiveUI.Extensions.Tests/Operators/WhileObservableTests.cs
@@ -1,0 +1,126 @@
+// Copyright (c) 2019-2026 ReactiveUI Association Incorporated. All rights reserved.
+// ReactiveUI Association Incorporated licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+namespace ReactiveUI.Extensions.Tests.Operators;
+
+/// <summary>Edge-case coverage for the <c>While</c> operator backed by
+/// <c>WhileObservable</c> — inline iteration, scheduler dispatch, predicate-throws,
+/// action-throws, and dispose-during-iteration paths.</summary>
+public class WhileObservableTests
+{
+    /// <summary>Synthetic error message attached to predicate failures.</summary>
+    private const string PredicateFailedMessage = "predicate failed";
+
+    /// <summary>Synthetic error message attached to action failures.</summary>
+    private const string ActionFailedMessage = "action failed";
+
+    /// <summary>Number of inline iterations to run.</summary>
+    private const int IterationCount = 3;
+
+    /// <summary>Settle delay in milliseconds used to confirm a disposed loop stops ticking.</summary>
+    private const int SettleDelayMilliseconds = 50;
+
+    /// <summary>Maximum tolerated extra iterations after Dispose() returns.</summary>
+    private const int MaxStragglerIterations = 10;
+
+    /// <summary>Verifies that the inline form runs until the predicate returns <c>false</c>.</summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous test operation.</returns>
+    [Test]
+    public async Task WhenWhileInline_ThenRunsUntilPredicateFalseAndCompletes()
+    {
+        var remaining = IterationCount;
+        var emitted = 0;
+        var completed = false;
+
+        using var sub = ReactiveExtensions.While(() => remaining > 0, () => remaining--)
+            .Subscribe(_ => emitted++, () => completed = true);
+
+        await Assert.That(emitted).IsEqualTo(IterationCount);
+        await Assert.That(completed).IsTrue();
+        await Assert.That(remaining).IsEqualTo(0);
+    }
+
+    /// <summary>Verifies that the scheduler form dispatches every iteration via the scheduler.</summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous test operation.</returns>
+    [Test]
+    public async Task WhenWhileWithScheduler_ThenRunsUntilPredicateFalse()
+    {
+        var remaining = IterationCount;
+        var completed = new TaskCompletionSource<int>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var emitted = 0;
+
+        using var sub = ReactiveExtensions.While(() => remaining > 0, () => remaining--, TaskPoolScheduler.Default)
+            .Subscribe(_ => emitted++, () => completed.TrySetResult(emitted));
+
+        var final = await completed.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        await Assert.That(final).IsEqualTo(IterationCount);
+    }
+
+    /// <summary>Verifies that an exception thrown by the predicate is forwarded.</summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous test operation.</returns>
+    [Test]
+    public async Task WhenWhilePredicateThrows_ThenForwardsError()
+    {
+        Exception? caught = null;
+        var expected = new InvalidOperationException(PredicateFailedMessage);
+
+        using var sub = ReactiveExtensions.While(() => throw expected, static () => { })
+            .Subscribe(static _ => { }, ex => caught = ex);
+
+        await Assert.That(caught).IsSameReferenceAs(expected);
+    }
+
+    /// <summary>Verifies that an exception thrown by the action is forwarded.</summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous test operation.</returns>
+    [Test]
+    public async Task WhenWhileActionThrows_ThenForwardsError()
+    {
+        Exception? caught = null;
+        var expected = new InvalidOperationException(ActionFailedMessage);
+
+        using var sub = ReactiveExtensions.While(static () => true, () => throw expected)
+            .Subscribe(static _ => { }, ex => caught = ex);
+
+        await Assert.That(caught).IsSameReferenceAs(expected);
+    }
+
+    /// <summary>Verifies that disposing the scheduled loop stops further iterations.</summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous test operation.</returns>
+    [Test]
+    public async Task WhenWhileScheduledThenDisposed_ThenIterationStops()
+    {
+        var ran = 0;
+        var gate = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        var sub = ReactiveExtensions.While(
+                static () => true,
+                () => SignalFirstIteration(ref ran, gate),
+                TaskPoolScheduler.Default)
+            .Subscribe(static _ => { });
+
+        await gate.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        sub.Dispose();
+
+        var snapshot = Volatile.Read(ref ran);
+        await Task.Delay(SettleDelayMilliseconds).ConfigureAwait(false);
+        var later = Volatile.Read(ref ran);
+
+        // The loop may execute a few more iterations between Dispose() being called
+        // and the next disposal-check, but it must not keep ticking forever.
+        await Assert.That(later - snapshot).IsLessThanOrEqualTo(MaxStragglerIterations);
+    }
+
+    /// <summary>Increments <paramref name="counter"/> and signals <paramref name="gate"/> on the first iteration.</summary>
+    /// <param name="counter">Shared iteration counter.</param>
+    /// <param name="gate">Completion source signalled after the first iteration.</param>
+    private static void SignalFirstIteration(ref int counter, TaskCompletionSource<bool> gate)
+    {
+        if (Interlocked.Increment(ref counter) != 1)
+        {
+            return;
+        }
+
+        gate.TrySetResult(true);
+    }
+}


### PR DESCRIPTION
## Summary

Two-batch test coverage expansion targeting low-coverage operators (by uncovered-line count), plus a fix for a flaky test that hit the 60s timeout under parallel cross-framework runs.

### Batch 1 — focused edge-case tests
- `SelectLatestAsync` / `SelectAsyncSequential` / `SelectAsyncConcurrent`: error, dispose-mid-flight, deferred completion
- `UsingAction` / `StartAction`: scheduler dispatch, action-throws, sync inline
- `SampleLatest`: trigger-before-value, trigger error, trigger-completion does not terminate
- `ObserveOnIf` (reactive condition): scheduler swap on condition transitions
- `Partition`: routing, single-side disposal, error/completion broadcast, resubscription
- `ThrottleUntilTrue`: predicate bypass, throttle replacement, dispose-before-fire
- `BooleanReduce` (`AllTrue`/`AllFalse`): empty-source short-circuit, partial suppression, transitions
- `MinMax` (`GetMin`/`GetMax`): partial suppression, error propagation
- `CatchAndReturn` factory overload: matching/non-matching exception, factory-throws

### Batch 2 — line-count-prioritised follow-ups
- `WhileObservable`: inline + scheduler iteration, predicate/action throws, dispose-stops-loop
- `RunAllObservable`: empty short-circuit, sync/async walk, error/disposal mid-walk
- `SubscribeAsyncObservable`: ordered handler invocation, handler-throws, deferred completion
- `ObservableSubscriptionExtensions`: scheduler-routed `WaitFor*` overloads
- `CurrentValueSubject`: multi-observer broadcast, mid-array dispose, collapse to single, post-terminal subscribe
- `ConflateObservable`: source-error path, newer-value replaces pending, dispose-before-emission
- `ScanWithInitial`: terminal forwarding and post-terminal ignore
- `SelectManyThenObservable`: two-stage projection, projection/inner errors
- `DisposableBag`: inline-fill, overflow growth, add-after-dispose, idempotent dispose
- `PropertyChangedObservable`: initial emission, name filtering, getter-throws on change, dispose detaches handler

### Flaky test fix
`WhenMergeConcurrencyWithSlowSource_ThenLimitsAndCompletes` was hitting the 60s per-test timeout when net8/9/10 test assemblies ran in parallel — the default `CreateAsBackgroundJob` path uses `Task.Yield()` onto the thread pool, which starved under cross-assembly load. Switched to `startSynchronously: true` so the concurrency-cap contract is still exercised without depending on free thread-pool threads. Full suite now completes in ~20s per framework instead of timing out.

## Test plan
- [x] `dotnet build ReactiveUI.Extensions.slnx -c Release -warnaserror` — clean
- [x] `dotnet test --solution ReactiveUI.Extensions.slnx -c Release` — 4611 tests, 0 failed across net8.0/net9.0/net10.0
- [x] Per-framework run completes in ~20s (down from net8.0 timing out at 1m20s)